### PR TITLE
test: add runc smoke-test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN zypper -n in \
 		oci-image-tools \
 		oci-runtime-tools \
 		python-setuptools python-xattr attr \
+		runc \
 		skopeo \
 		tar
 RUN useradd -u 1000 -m -d /home/rootless -s /bin/bash rootless

--- a/oci/layer/tar_extract_test.go
+++ b/oci/layer/tar_extract_test.go
@@ -741,8 +741,7 @@ func TestUnpackHardlink(t *testing.T) {
 // TestUnpackEntryMap checks that the mapOptions handling works.
 func TestUnpackEntryMap(t *testing.T) {
 	if os.Geteuid() != 0 {
-		t.Log("mapOptions tests only work with root privileges")
-		t.Skip()
+		t.Skip("mapOptions tests only work with root privileges")
 	}
 
 	// TODO: Modify this to use subtests once Go 1.7 is in enough places.

--- a/pkg/unpriv/unpriv_test.go
+++ b/pkg/unpriv/unpriv_test.go
@@ -32,8 +32,7 @@ import (
 
 func TestWrapNoTricks(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestWrapNoTricks")
@@ -67,8 +66,7 @@ func TestWrapNoTricks(t *testing.T) {
 
 func TestLstat(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestLstat")
@@ -151,8 +149,7 @@ func TestLstat(t *testing.T) {
 
 func TestReadlink(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestReadlink")
@@ -241,8 +238,7 @@ func TestReadlink(t *testing.T) {
 
 func TestSymlink(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestSymlink")
@@ -333,8 +329,7 @@ func TestSymlink(t *testing.T) {
 
 func TestOpen(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestOpen")
@@ -471,8 +466,7 @@ func TestOpen(t *testing.T) {
 
 func TestReaddir(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestReaddir")
@@ -595,8 +589,7 @@ func TestReaddir(t *testing.T) {
 
 func TestWrapWrite(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestWrapWrite")
@@ -678,8 +671,7 @@ func TestWrapWrite(t *testing.T) {
 
 func TestLink(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestLink")
@@ -843,14 +835,12 @@ func TestLink(t *testing.T) {
 
 func TestLchownRemove(t *testing.T) {
 	// FIXME: We probably should remove Lchown.
-	t.Log("unpriv.Lchown cannot really be tested")
-	t.Skip()
+	t.Skip("unpriv.Lchown cannot really be tested")
 }
 
 func TestChtimes(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestChtimes")
@@ -963,8 +953,7 @@ func TestChtimes(t *testing.T) {
 
 func TestLutimes(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestLutimes")
@@ -1125,8 +1114,7 @@ func TestLutimes(t *testing.T) {
 
 func TestRemove(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestRemove")
@@ -1208,8 +1196,7 @@ func TestRemove(t *testing.T) {
 
 func TestRemoveAll(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestRemoveAll")
@@ -1281,8 +1268,7 @@ func TestRemoveAll(t *testing.T) {
 
 func TestMkdir(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestMkdir")
@@ -1366,8 +1352,7 @@ func TestMkdir(t *testing.T) {
 
 func TestMkdirAll(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestMkdirAll")
@@ -1486,8 +1471,7 @@ func TestMkdirAll(t *testing.T) {
 
 func TestMkdirAllMissing(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestMkdirAllMissing")
@@ -1583,8 +1567,7 @@ func TestMkdirAllMissing(t *testing.T) {
 // (specifically /var/log/anaconda/pre-anaconda-logs/lvmdump).
 func TestMkdirRWPerm(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestMkdirRWPerm")
@@ -1703,8 +1686,7 @@ func TestMkdirRWPerm(t *testing.T) {
 // are handled correctly with Mkdir or Create.
 func TestMkdirRPerm(t *testing.T) {
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestMkdirRPerm")
@@ -1799,8 +1781,7 @@ func TestWalk(t *testing.T) {
 	// expected.
 
 	if os.Geteuid() == 0 {
-		t.Log("unpriv.* tests only work with non-root privileges")
-		t.Skip()
+		t.Skip("unpriv.* tests only work with non-root privileges")
 	}
 
 	dir, err := ioutil.TempDir("", "umoci-unpriv.TestWalk")

--- a/test/runc.bats
+++ b/test/runc.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats -t
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2016-2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+function setup() {
+	setup_tmpdirs
+	setup_image
+	setup_runc
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+	teardown_runc
+}
+
+@test "umoci + runc [smoke test]" {
+	CTR_NAME="umoci-test-$RANDOM"
+	LOGFILE="$(setup_tmpdir)/umoci-runc-debug.log"
+
+	# Modify the image so that we run a command that's easy to check.
+	umoci config --image "${IMAGE}:${TAG}" \
+		--config.entrypoint "/bin/echo" --config.cmd "hello umoci"
+	[ "$status" -eq 0 ]
+	image-verify "$IMAGE"
+
+	# Unpack the image.
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	# Bats runs without stdin, which causes runc to be quite unhappy. See
+	# <https://github.com/opencontainers/runc/issues/2485> for more details.
+	jq '.process.terminal = false' "$BUNDLE/config.json" | sponge "$BUNDLE/config.json"
+
+	# Run the container.
+	runc --debug --log "$LOGFILE" run -b "$BUNDLE" "$CTR_NAME"
+	# Get the logfile contents.
+	echo "=== [runc --debug logfile]" >&2
+	cat "$LOGFILE" >&2
+	echo "===" >&2
+	[ "$status" -eq 0 ]
+	[[ "$output" == "hello umoci" ]]
+}


### PR DESCRIPTION
We've had cases where the default setup of "umoci + runc" didn't work
(usually in rootless container scenarios). Since this is a very common
usage of umoci, it makes sense to check it.

Signed-off-by: Aleksa Sarai <asarai@suse.de>