### PR TITLE
GC: add support for GC policies

### DIFF
--- a/oci/casext/gc_test.go
+++ b/oci/casext/gc_test.go
@@ -3,12 +3,14 @@ package casext
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	imeta "github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci/oci/cas/dir"
@@ -173,5 +175,145 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 	}
 	if len(b) != 1 {
 		t.Fatalf("expected single-entry blob list after GC")
+	}
+}
+
+func gcOkFunc(t *testing.T, expectedDigest digest.Digest, unexpectedDigest digest.Digest) GCPolicy {
+	return func(ctx context.Context, digest digest.Digest) (bool, error) {
+		if digest == "" || digest == unexpectedDigest {
+			t.Errorf("got incorrect digest to gc policy callback: unexpected %v", digest)
+		}
+		if digest != expectedDigest {
+			t.Errorf("got incorrect digest to gc policy callback: expected %v, got %v", expectedDigest, digest)
+		}
+		return true, nil
+	}
+}
+
+func gcSkipFunc(t *testing.T, expectedDigest digest.Digest) GCPolicy {
+	return func(ctx context.Context, digest digest.Digest) (bool, error) {
+		if digest != expectedDigest {
+			t.Errorf("got incorrect digest to gc policy callback: expected %v, got %v", expectedDigest, digest)
+		}
+		return false, nil
+	}
+}
+
+func errFunc(ctx context.Context, digest digest.Digest) (bool, error) {
+	return false, fmt.Errorf("err policy")
+}
+
+func TestGCWithPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	root, err := ioutil.TempDir("", "umoci-TestEngineReference")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	image := filepath.Join(root, "image")
+	if err := dir.Create(image); err != nil {
+		t.Fatalf("unexpected error creating image: %+v", err)
+	}
+
+	engine, err := dir.Open(image)
+	if err != nil {
+		t.Fatalf("unexpected error opening image: %+v", err)
+	}
+	engineExt := NewEngine(engine)
+	defer engine.Close()
+
+	// build a orphan blob that should be GC'ed
+	content := "this is a orphan blob"
+	br := strings.NewReader(content)
+	odigest, size, err := engine.PutBlob(ctx, br)
+	if err != nil {
+		t.Fatalf("error writing blob: %+v", err)
+	}
+	if size != int64(len(content)) {
+		t.Fatalf("partially written blob")
+	}
+
+	// build a blob, manifest, index that will survive GC
+	content = "this is a test blob"
+	br = strings.NewReader(content)
+	digest, size, err := engine.PutBlob(ctx, br)
+	if err != nil {
+		t.Fatalf("error writing blob: %+v", err)
+	}
+	if size != int64(len(content)) {
+		t.Fatalf("partially written blob")
+	}
+
+	digest, size, err = engineExt.PutBlobJSON(ctx,
+		ispec.Manifest{
+			Versioned: imeta.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageLayer,
+				Digest:    digest,
+				Size:      size,
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: ispec.MediaTypeImageLayer,
+					Digest:    digest,
+					Size:      size,
+				},
+			},
+		})
+	if err != nil {
+		t.Fatalf("error writing blob: %+v", err)
+	}
+
+	idx := ispec.Index{
+		Versioned: imeta.Versioned{
+			SchemaVersion: 2,
+		},
+		Manifests: []ispec.Descriptor{
+			{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    digest,
+				Size:      size,
+			},
+		},
+	}
+	if err := engine.PutIndex(ctx, idx); err != nil {
+		t.Fatalf("error writing index: %+v", err)
+	}
+
+	err = engineExt.GC(ctx, errFunc)
+	// expect this to fail
+	if err == nil {
+		t.Fatalf("GC failed: %+v", err)
+	}
+
+	err = engineExt.GC(ctx, gcSkipFunc(t, odigest))
+	// expect this to succeed but not perform GC
+	if err != nil {
+		t.Fatalf("GC failed: %+v", err)
+	}
+	b, err := engine.ListBlobs(ctx)
+	if err != nil {
+		t.Fatalf("unable to list blobs: %+v", err)
+	}
+	if len(b) != 3 {
+		t.Fatalf("expected all entries in blob list after skip GC policy")
+	}
+
+	err = engineExt.GC(ctx, gcOkFunc(t, odigest, digest))
+	// expect this to succeed
+	if err != nil {
+		t.Fatalf("GC failed: %+v", err)
+	}
+
+	b, err = engine.ListBlobs(ctx)
+	if err != nil {
+		t.Fatalf("unable to list blobs: %+v", err)
+	}
+	if len(b) != 2 {
+		t.Fatalf("expected blob list with two entries after GC")
 	}
 }


### PR DESCRIPTION
For our dist-spec implementation [1][2],
we have a use case where we use umoci's GC code to clean up orphaned
blobs. The issue is that as per dist-spec layer upload and manifest
updates are two different API calls and typically in that order, which
means layers begin life as orphans.

Adding the proposed patch allows us to:
a) mitigate the above issue
b) have a generic policy framework for future expansion

[1] https://github.com/opencontainers/distribution-spec
[2] https://github.com/anuvu/zot