### PR TITLE
overlay support: allow syscall.Stat_t too

### DIFF
--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -85,7 +85,11 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 						return errors.Wrapf(err, "couldn't determine overlay whiteout for %s", fullPath)
 					}
 
-					if isOverlayWhiteout(fi) {
+					whiteout, err := isOverlayWhiteout(fi)
+					if err != nil {
+						return err
+					}
+					if whiteout {
 						if err := tg.AddWhiteout(fullPath); err != nil {
 							return errors.Wrap(err, "generate whiteout from overlayfs")
 						}
@@ -150,7 +154,11 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 			}
 
 			pathInTar := path.Join(target, curPath[len(root):])
-			if packOptions.TranslateOverlayWhiteouts && isOverlayWhiteout(info) {
+			whiteout, err := isOverlayWhiteout(info)
+			if err != nil {
+				return err
+			}
+			if packOptions.TranslateOverlayWhiteouts && whiteout {
 				log.Debugf("converting overlayfs whiteout %s to OCI whiteout", pathInTar)
 				return tg.AddWhiteout(pathInTar)
 			}

--- a/oci/layer/tar_extract_linux_test.go
+++ b/oci/layer/tar_extract_linux_test.go
@@ -94,7 +94,11 @@ func TestUnpackEntryOverlayFSWhiteout(t *testing.T) {
 		t.Fatalf("failed to stat `file`: %v", err)
 	}
 
-	if !isOverlayWhiteout(fi) {
+	whiteout, err := isOverlayWhiteout(fi)
+	if err != nil {
+		t.Fatalf("failed to check overlay whiteout: %v", err)
+	}
+	if !whiteout {
 		t.Fatalf("extract didn't make overlay whiteout")
 	}
 


### PR DESCRIPTION
I'm getting stack traces like this:

panic: interface conversion: interface {} is *syscall.Stat_t, not *unix.Stat_t
goroutine 23 [running]:
github.com/opencontainers/umoci/oci/layer.isOverlayWhiteout(0xe93f60, 0xc000094000, 0x2)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/oci/layer/utils.go:233 +0xe5
github.com/opencontainers/umoci/oci/layer.GenerateInsertLayer.func1.2(0xc000048e00, 0x7e, 0xe93f60, 0xc000094000, 0x0, 0x0, 0x0, 0x0)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/oci/layer/generate.go:153 +0x169
github.com/opencontainers/umoci/pkg/unpriv.walk(0xc000048e00, 0x7e, 0xe93f60, 0xc000094000, 0xc00006eec8, 0x0, 0x5)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/pkg/unpriv/unpriv.go:535 +0x63
github.com/opencontainers/umoci/pkg/unpriv.Walk.func1(0xc000048e00, 0x7e, 0x203000, 0x203000)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/pkg/unpriv/unpriv.go:574 +0x145
github.com/opencontainers/umoci/pkg/unpriv.Wrap(0xc000048e00, 0x7e, 0xc00006edc8, 0x0, 0x0)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/pkg/unpriv/unpriv.go:75 +0x62
github.com/opencontainers/umoci/pkg/unpriv.Walk(0xc000048e00, 0x7e, 0xc00006eec8, 0x60, 0xd4d680)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/pkg/unpriv/unpriv.go:569 +0x5d
github.com/opencontainers/umoci/oci/layer.GenerateInsertLayer.func1(0xc000010700, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x487f00, ...)
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/oci/layer/generate.go:147 +0x3a9
created by github.com/opencontainers/umoci/oci/layer.GenerateInsertLayer
	/home/travis/gopath/pkg/mod/github.com/opencontainers/umoci@v0.4.7-0.20200930143527-05c30365a674/oci/layer/generate.go:131 +0x285

So it seems that some versions of the unix pkg emit syscall.Stat_t, and others
use unix.Stat_t. This is why we can't have nice things.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>