### PR TITLE
layer: ignore overlay.impure xattr

### DIFF
--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -49,6 +49,17 @@ var ignoreXattrs = map[string]struct{}{
 	// In order to support overlayfs whiteout mode, we shouldn't un-set
 	// this after we've set it when writing out the whiteouts.
 	"trusted.overlay.opaque": {},
+
+	// We don't want to these xattrs into the image, because they're only
+	// relevant based on how the build overlay is constructed and will not
+	// be true on the target system once the image is unpacked (e.g. inodes
+	// might be different, impure status won't be true, etc.).
+	"trusted.overlay.redirect": {},
+	"trusted.overlay.origin":   {},
+	"trusted.overlay.impure":   {},
+	"trusted.overlay.nlink":    {},
+	"trusted.overlay.upper":    {},
+	"trusted.overlay.metacopy": {},
 }
 
 func init() {


### PR DESCRIPTION
See comment for details; basically this is a during-image-build-time-only
thing.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>