### PR TITLE
Fuzzing: Add 2 fuzzers

### DIFF
--- a/oci/casext/fuzzer.go
+++ b/oci/casext/fuzzer.go
@@ -1,0 +1,66 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2021 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// +build gofuzz
+
+package casext
+
+import (
+	"context"
+	"github.com/opencontainers/umoci/oci/cas/dir"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// Fuzz implements the fuzz harness
+func Fuzz(data []byte) int {
+	ctx := context.Background()
+	root, err := ioutil.TempDir("", "umoci-TestEngineBlobJSON")
+	if err != nil {
+		return -1
+	}
+	defer os.RemoveAll(root)
+
+	image := filepath.Join(root, "image")
+	if err := dir.Create(image); err != nil {
+		return -1
+	}
+
+	engine, err := dir.Open(image)
+	if err != nil {
+		return -1
+	}
+	engineExt := NewEngine(engine)
+	defer engine.Close()
+
+	digest, _, err := engineExt.PutBlobJSON(ctx, string(data))
+	if err != nil {
+		return 0
+	}
+	blobReader, err := engine.GetBlob(ctx, digest)
+	if err != nil {
+		return 0
+	}
+	defer blobReader.Close()
+
+	_, err = ioutil.ReadAll(blobReader)
+	if err != nil {
+		return 0
+	}
+	return 1
+}

--- a/pkg/hardening/fuzzer.go
+++ b/pkg/hardening/fuzzer.go
@@ -1,0 +1,47 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2021 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// +build gofuzz
+
+package hardening
+
+import (
+	"bytes"
+	_ "crypto/sha256" // Import is necessary for go-digest
+	"github.com/opencontainers/go-digest"
+	"io/ioutil"
+)
+
+// Fuzz implements the go-fuzz harness
+func Fuzz(data []byte) int {
+	buffer := bytes.NewBuffer(data)
+	size := len(data)
+	if !digest.SHA256.Available() {
+		return -1
+	}
+	expectedDigest := digest.SHA256.FromBytes(buffer.Bytes())
+	verifiedReader := &VerifiedReadCloser{
+		Reader:         ioutil.NopCloser(buffer),
+		ExpectedDigest: expectedDigest,
+		ExpectedSize:   int64(size),
+	}
+	_, err := verifiedReader.Read(data)
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds two fuzzers that were originally committed to OSS-fuzz. As it is unsure whether or not Umoci qualifies for OSS-fuzz integration, I am moving them over here.

I will be adding more fuzzers as well as documentation on running these locally in later PRs.

Signed-off-by: AdamKorcz <adam@adalogics.com>