### PR TITLE
makefile: fix bad build flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ BASE_LDFLAGS := -s -w -X ${PROJECT}.gitCommit=${COMMIT} -X ${PROJECT}.version=${
 
 # Specific build flags for build type.
 ifeq ($(GOOS), linux)
-	TEST_BUILD_FLAGS := ${BASE_FLAGS} -buildmode=pie -ldflags "${BASE_LDFLAGS} -X ${PROJECT}/pkg/testutils.binaryType=test"		   DYN_BUILD_FLAGS := ${BASE_FLAGS} -buildmode=pie -ldflags "${BASE_LDFLAGS}"
+	DYN_BUILD_FLAGS := ${BASE_FLAGS} -buildmode=pie -ldflags "${BASE_LDFLAGS}"
 	TEST_BUILD_FLAGS := ${BASE_FLAGS} -buildmode=pie -ldflags "${BASE_LDFLAGS} -X ${PROJECT}/pkg/testutils.binaryType=test"
 else
 	DYN_BUILD_FLAGS := ${BASE_FLAGS} -ldflags "${BASE_LDFLAGS}"

--- a/test/help.bats
+++ b/test/help.bats
@@ -17,13 +17,15 @@
 load helpers
 
 @test "umoci --version" {
+	VERSION="$(cat "$INTEGRATION_ROOT/../VERSION")"
+
 	umoci --version
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "umoci version "+ ]]
+	[[ "$output" =~ "umoci version $VERSION"+ ]]
 
 	umoci -v
 	[ "$status" -eq 0 ]
-	[[ "$output" =~ "umoci version "+ ]]
+	[[ "$output" =~ "umoci version $VERSION"+ ]]
 }
 
 @test "umoci --help" {


### PR DESCRIPTION
Fix mistake in the Makefile which prevents the version field (as well as
some other build flags) from being passed to "go build".

Fixes: 6fbd32e48b66 ("Make Makefile more portable")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>