### PR TITLE
ci: verify codecov hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ DOCKER_RUN = docker run --rm -v ${PWD}:/go/src/${PROJECT} \
 # Travis, to avoid pinging third-party servers for local builds.
 ifdef TRAVIS
 $(shell echo "WARNING: This make invocation will fetch and run code from https://codecov.io/." >&2)
-DOCKER_RUN += $(shell echo "+ curl -sSL https://codecov.io/env | bash" >&2) \
-              $(shell ./hack/resilient-curl.sh -sSL https://codecov.io/env | bash)
+DOCKER_RUN += $(shell echo "+ Running https://codecov.io/env." >&2) \
+              $(shell ./hack/ci-codecov.sh env)
 endif
 
 DOCKER_ROOTPRIV_RUN = $(DOCKER_RUN) --privileged --cap-add=SYS_ADMIN

--- a/hack/ci-codecov.sh
+++ b/hack/ci-codecov.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2016-2021 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeuxo pipefail
+source "$(dirname "$BASH_SOURCE")/readlinkf.sh"
+
+CODECOV_DIR="$(mktemp -dt umoci-codecov.XXXXXX)"
+#trap 'rm -rf $CODECOV_DIR' EXIT
+
+export ROOT="$(readlinkf_posix "$(dirname "$BASH_SOURCE")/..")"
+
+# Download the codecov-bash uploader from GitHub and check the SHA512.
+CODECOV_VERSION="e42edd84d7b19089c3e314661a7699c3b594300f" # to be able to check 'env' as well
+CODECOV_REPOURL="https://raw.githubusercontent.com/codecov/codecov-bash/$CODECOV_VERSION"
+
+echo "WARNING: Downloading and executing codecov-bash, which will upload data." >&2
+sleep 1s
+
+cmd="$1"
+shift
+
+"$ROOT/hack/resilient-curl.sh" -sSL "$CODECOV_REPOURL/$cmd" -o "$CODECOV_DIR/$cmd"
+"$ROOT/hack/resilient-curl.sh" -sSL "$CODECOV_REPOURL/SHA512SUM" -o "$CODECOV_DIR/SHA512SUM"
+
+pushd "$CODECOV_DIR" >/dev/null
+sha512sum -c --ignore-missing --quiet ./SHA512SUM || exit 1
+chmod +x "$cmd"
+popd >/dev/null
+
+exec "$CODECOV_DIR/$cmd" "$@"

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -61,8 +61,7 @@ then
 	find "$COVERAGE_DIR" -type f -print0 | xargs -0 "$ROOT/hack/collate.awk" >"$tmp_coverage"
 
 	# Upload the merged coverage file.
-	"$ROOT/hack/resilient-curl.sh" -sSL https://codecov.io/bash | \
-		bash -s -- -cZ -f "$tmp_coverage" -F "$coverage_tags"
+	"$ROOT/hack/ci-codecov.sh" codecov -cZ -f "$tmp_coverage" -F "$coverage_tags"
 elif [ -n "$COVERAGE" ]
 then
 	# If running locally, collate the coverage information.

--- a/hack/test-unit.sh
+++ b/hack/test-unit.sh
@@ -45,8 +45,7 @@ then
 
 	# If we're running in Travis, upload the coverage files and don't bother
 	# with the local coverage generation.
-	"$ROOT/hack/resilient-curl.sh" -sSL https://codecov.io/bash | \
-		bash -s -- -cZ -f "$COVERAGE_FILE" -F "$coverage_tags"
+	"$ROOT/hack/ci-codecov.sh" codecov -cZ -f "$COVERAGE_FILE" -F "$coverage_tags"
 elif [ -n "$COVERAGE" ]
 then
 	# If running locally, collate the coverage information.


### PR DESCRIPTION
We don't have any secrets in our CI, but it doesn't hurt to be sure now
that they actually publish hashes in a way that we can easily verify. We
can also pin the version (though in the future we should probably pull
the script from codecov.io and verify it using GitHub separately).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>