### PR TITLE
Add documentation for running fuzzers

### DIFF
--- a/Dockerfile.fuzz
+++ b/Dockerfile.fuzz
@@ -1,0 +1,17 @@
+FROM golang:1.14
+
+RUN apt-get update && apt-get install -y clang
+
+RUN go get -u github.com/dvyukov/go-fuzz/go-fuzz \
+	github.com/dvyukov/go-fuzz/go-fuzz-dep \
+	github.com/dvyukov/go-fuzz/go-fuzz-build
+
+COPY . $GOPATH/src/github.com/opencontainers/umoci
+
+WORKDIR $GOPATH/src/github.com/opencontainers/umoci
+
+RUN go clean --modcache && \
+    go mod tidy && \
+    go mod vendor && \
+    rm -r ./vendor
+

--- a/test/fuzzing/README.md
+++ b/test/fuzzing/README.md
@@ -1,0 +1,30 @@
+# Fuzzing umoci
+
+Umoci has a series of fuzz tests. These are implemented by way of [go-fuzz](https://github.com/dvyukov/go-fuzz).
+
+## Running the fuzzers
+
+To run the fuzzers, first build the fuzzer image from the root of this repository:
+
+```bash
+sudo docker build -t umoci-fuzz -f Dockerfile.fuzz .
+```
+Next, get a shell in the container:
+```bash
+sudo docker run -it umoci-fuzz
+```
+At this point, you can navigate to any directory that has a fuzzer and build it:
+
+```bash
+cd $PATH_TO_FUZZER
+go-fuzz-build -libfuzzer -func=FUZZ_NAME && \
+clang -fsanitize=fuzzer PACKAGE_NAME.a -o fuzzer
+```
+`FUZZ_NAME` will typically be `Fuzz`, but in some cases the respective fuzzers will have more descriptive names. 
+
+If you encounter any errors when linking with `PACKAGE_NAME.a`, simply `ls` after running `go-fuzz-build...`, and you will see the archive to link with.
+
+If everything goes well until this point, you can run the fuzzer:
+```bash
+./fuzzer
+```


### PR DESCRIPTION
This PR adds documentation on running the fuzzers locally. 

It adds the `/test/fuzzing` that holds the Dockerfile and the Readme.