### PR TITLE
oci: casext: walk: do not attempt to recurse into un-parseable blobs 

### DIFF
--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -70,7 +70,20 @@ type Engine interface {
 
 	// GetBlob returns a reader for retrieving a blob from the image, which the
 	// caller must Close(). Returns ErrNotExist if the digest is not found.
+	//
+	// This function will return a VerifiedReadCloser, meaning that you must
+	// call Close() and check the error returned from Close() in order to
+	// ensure that the hash of the blob is verified.
+	//
+	// Please note that calling Close() on the returned blob will read the
+	// entire from disk and hash it (even if you didn't read any bytes before
+	// calling Close), so if you wish to only check if a blob exists you should
+	// use StatBlob() instead.
 	GetBlob(ctx context.Context, digest digest.Digest) (reader io.ReadCloser, err error)
+
+	// StatBlob returns whether the specified blob exists in the image. Returns
+	// ErrNotExist if the digest was not found.
+	StatBlob(ctx context.Context, digest digest.Digest) (bool, error)
 
 	// PutIndex sets the index of the OCI image to the given index, replacing
 	// the previously existing index. This operation is atomic; any readers


### PR DESCRIPTION
Since all of these blobs are not parseable, we won't be able to fetch
sub-descriptors from them, and thus there's no real point trying to
recurse into them. Before commit 4faf753 ("pkg: hardening: slurp
trailing bytes in VerifiedReadCloser.Close()") this wasn't too big of a
deal, but after that commit Close() is quite expensive for blobs you
don't use.

Reported-by: Tycho Andersen <tycho@tycho.pizza>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>