### PR TITLE
*: use go1.17-friendly go:build tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1'
+          # We currently need to pick a set Go version because sometimes Go
+          # updates will change the output of gofmt. Ideally we would have some
+          # kind of lint checker that doesn't fail the CI completely and
+          # instead just gives us nice warnings but for now just pin a Go
+          # version.
+          go-version: '1.17.x'
       - name: install dependencies
         run: |
           # TODO: Move this to 'make fetch-deps'.

--- a/mutate/mutate_fuzzer.go
+++ b/mutate/mutate_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/oci/casext/fuzzer.go
+++ b/oci/casext/fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/oci/config/convert/utils_unix.go
+++ b/oci/config/convert/utils_unix.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*

--- a/oci/layer/generate_linux_test.go
+++ b/oci/layer/generate_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package layer

--- a/oci/layer/layer_fuzzer.go
+++ b/oci/layer/layer_fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/oci/layer/tar_extract_linux_test.go
+++ b/oci/layer/tar_extract_linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/hardening/fuzzer.go
+++ b/pkg/hardening/fuzzer.go
@@ -1,3 +1,4 @@
+//go:build gofuzz
 // +build gofuzz
 
 /*

--- a/pkg/system/mknod_unix.go
+++ b/pkg/system/mknod_unix.go
@@ -1,3 +1,4 @@
+//go:build !freebsd
 // +build !freebsd
 
 /*

--- a/pkg/testutils/ftimes_unix.go
+++ b/pkg/testutils/ftimes_unix.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 /*

--- a/pkg/testutils/mount_linux.go
+++ b/pkg/testutils/mount_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*

--- a/pkg/testutils/mount_unsupported.go
+++ b/pkg/testutils/mount_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 /*


### PR DESCRIPTION
Go 1.17 adds the new "//go:build ..." style of build tags, and gofmt now
requires them to be used so add them -- CI is failing otherwise.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>