### PR TITLE
mutator: .Config() should return ispec.Image vs. ImageConfig

### DIFF
--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -170,7 +170,7 @@ func config(ctx *cli.Context) error {
 		return errors.Wrap(err, "create mutator for manifest")
 	}
 
-	imageConfig, err := mutator.Config(context.Background())
+	config, err := mutator.Config(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "get base config")
 	}
@@ -185,7 +185,7 @@ func config(ctx *cli.Context) error {
 		return errors.Wrap(err, "get base annotations")
 	}
 
-	g, err := igen.NewFromImage(toImage(imageConfig, imageMeta))
+	g, err := igen.NewFromImage(toImage(config.Config, imageMeta))
 	if err != nil {
 		return errors.Wrap(err, "create new generator")
 	}

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -133,7 +133,7 @@ func repack(ctx *cli.Context) error {
 
 	maskedPaths := ctx.StringSlice("mask-path")
 	if !ctx.Bool("no-mask-volumes") {
-		for v := range config.Volumes {
+		for v := range config.Config.Volumes {
 			maskedPaths = append(maskedPaths, v)
 		}
 	}

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -145,12 +145,12 @@ func New(engine cas.Engine, src casext.DescriptorPath) (*Mutator, error) {
 // Config returns the current (cached) image configuration, which should be
 // used as the source for any modifications of the configuration using
 // Set.
-func (m *Mutator) Config(ctx context.Context) (ispec.ImageConfig, error) {
+func (m *Mutator) Config(ctx context.Context) (ispec.Image, error) {
 	if err := m.cache(ctx); err != nil {
-		return ispec.ImageConfig{}, errors.Wrap(err, "getting cache failed")
+		return ispec.Image{}, errors.Wrap(err, "getting cache failed")
 	}
 
-	return m.config.Config, nil
+	return *m.config, nil
 }
 
 // Manifest returns the current (cached) image manifest. This is what will be

--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -593,13 +593,13 @@ func TestMutatePath(t *testing.T) {
 
 		// Change the label.
 		label := fmt.Sprintf("TestMutateSet+%d", idx)
-		if config.Labels == nil {
-			config.Labels = map[string]string{}
+		if config.Config.Labels == nil {
+			config.Config.Labels = map[string]string{}
 		}
-		config.Labels["org.opensuse.testidx"] = label
+		config.Config.Labels["org.opensuse.testidx"] = label
 
 		// Update it.
-		if err := mutator.Set(context.Background(), config, meta, nil, &ispec.History{
+		if err := mutator.Set(context.Background(), config.Config, meta, nil, &ispec.History{
 			Comment: "change label " + label,
 		}); err != nil {
 			t.Fatalf("%d: unexpected error modifying config: %+v", idx, err)

--- a/repack.go
+++ b/repack.go
@@ -97,7 +97,7 @@ func Repack(engineExt casext.Engine, tagName string, bundlePath string, meta Met
 			return err
 		}
 
-		err = mutator.Set(context.Background(), config, imageMeta, annotations, history)
+		err = mutator.Set(context.Background(), config.Config, imageMeta, annotations, history)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We're interested in caching the full config (including diffids) outside of
umoci during mutation, but the mutator provides no access. Let's make it
so.

I'm open to other ways to do this, but this patch seems to be working fine for me.