### PR TITLE
ci: osx: only try to unlink parallel if installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '^1'
       - name: install dependencies
         run: |
-          brew unlink parallel # clashes with moreutils
+          brew ls --versions parallel && brew unlink parallel # clashes with moreutils
           brew install coreutils moreutils
       - run: make local-validate-build
       - run: make local-test-unit


### PR DESCRIPTION
It seems GHA changed their default installed set of brew packages to no
longer include parallel, which causes the "brew unlink" command to fail.
So first check if parallel is installed.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>