### PR TITLE
oci: protect against mediatype confusion attacks (CVE-2021-41190)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN zypper -n in \
 		curl \
 		git \
 		gnu_parallel \
-		go1.14 \
+		"go>=1.16" \
 		go-mtree \
 		gzip \
 		jq \
@@ -56,7 +56,7 @@ RUN go get -u github.com/cpuguy83/go-md2man && \
     go get -u github.com/client9/misspell/cmd/misspell
 
 ENV SOURCE_IMAGE=/opensuse SOURCE_TAG=latest
-ARG DOCKER_IMAGE=opensuse/amd64:tumbleweed
+ARG DOCKER_IMAGE=registry.opensuse.org/opensuse/leap:15.2
 RUN skopeo copy docker://$DOCKER_IMAGE oci:$SOURCE_IMAGE:$SOURCE_TAG
 
 VOLUME ["/go/src/github.com/opencontainers/umoci"]

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ CACHE_IMAGE := $(CACHE)/ci-image.tar.zst
 
 .PHONY: ci-image
 ci-image:
-	docker pull registry.opensuse.org/opensuse/leap:latest
+	docker pull registry.opensuse.org/opensuse/leap:15.2
 	! [ -f "$(CACHE_IMAGE)" ] || unzstd < "$(CACHE_IMAGE)" | docker load
 	DOCKER_BUILDKIT=1 docker build -t $(UMOCI_IMAGE) \
 	                               --progress plain \

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -207,6 +207,9 @@ func (m *Mutator) Set(ctx context.Context, config ispec.ImageConfig, meta Meta, 
 		return errors.Wrap(err, "getting cache failed")
 	}
 
+	// Ensure the mediatype is correct.
+	m.manifest.MediaType = ispec.MediaTypeImageManifest
+
 	// Set annotations.
 	m.manifest.Annotations = annotations
 

--- a/mutate/mutate_fuzzer.go
+++ b/mutate/mutate_fuzzer.go
@@ -96,6 +96,7 @@ func fuzzSetup(dir string, data []byte) (cas.Engine, ispec.Descriptor, error) {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: ispec.MediaTypeImageManifest,
 		Config: ispec.Descriptor{
 			MediaType: ispec.MediaTypeImageConfig,
 			Digest:    configDigest,

--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -42,7 +42,7 @@ import (
 const (
 	expectedLayerDigest    = "sha256:96338a7c847bc582c82e4962a4285afcaf568e3913b0542b8745be27a418a806"
 	expectedConfigDigest   = "sha256:ddcc2a93d5b0bcdcb571431c3607d84abe3752406f7c631a898340e6e7e61ed0"
-	expectedManifestDigest = "sha256:0e8b342d2b01241b3f0197d0210ed5c0012d01817881defc1464e000f5b08f4d"
+	expectedManifestDigest = "sha256:a4f6551691241fd52bcabb6af7994c30e9f8c8fe3d5b6b0c1ffd137386689675"
 )
 
 func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
@@ -108,6 +108,7 @@ func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: ispec.MediaTypeImageManifest,
 		Config: ispec.Descriptor{
 			MediaType: ispec.MediaTypeImageConfig,
 			Digest:    configDigest,
@@ -554,6 +555,7 @@ func TestMutatePath(t *testing.T) {
 
 		// Create an Index that points to the old root.
 		newRoot := ispec.Index{
+			MediaType: ispec.MediaTypeImageIndex,
 			Manifests: []ispec.Descriptor{
 				oldPath.Root(),
 			},

--- a/new.go
+++ b/new.go
@@ -69,6 +69,7 @@ func NewImage(engineExt casext.Engine, tagName string) error {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2, // FIXME: This is hardcoded at the moment.
 		},
+		MediaType: ispec.MediaTypeImageManifest,
 		Config: ispec.Descriptor{
 			MediaType: ispec.MediaTypeImageConfig,
 			Digest:    configDigest,

--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -243,6 +243,9 @@ func (e *dirEngine) PutIndex(ctx context.Context, index ispec.Index) error {
 		return errors.Wrap(err, "ensure tempdir")
 	}
 
+	// Make sure the index has the mediatype field set.
+	index.MediaType = ispec.MediaTypeImageIndex
+
 	// We copy this into a temporary index to ensure the atomicity of this
 	// operation.
 	fh, err := ioutil.TempFile(e.temp, "index-")
@@ -442,6 +445,7 @@ func Create(path string) error {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2, // FIXME: This is hardcoded at the moment.
 		},
+		MediaType: ispec.MediaTypeImageIndex,
 	}
 	if err := json.NewEncoder(indexFh).Encode(defaultIndex); err != nil {
 		return errors.Wrap(err, "encode index.json")

--- a/oci/casext/gc_test.go
+++ b/oci/casext/gc_test.go
@@ -122,6 +122,7 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: ispec.MediaTypeImageManifest,
 		Config: ispec.Descriptor{
 			MediaType: ispec.MediaTypeImageLayer,
 			Digest:    digest,
@@ -152,6 +153,7 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: ispec.MediaTypeImageIndex,
 		Manifests: []ispec.Descriptor{
 			{
 				MediaType: ispec.MediaTypeImageManifest,
@@ -259,6 +261,7 @@ func TestGCWithPolicy(t *testing.T) {
 			Versioned: imeta.Versioned{
 				SchemaVersion: 2,
 			},
+			MediaType: ispec.MediaTypeImageManifest,
 			Config: ispec.Descriptor{
 				MediaType: ispec.MediaTypeImageLayer,
 				Digest:    digest,
@@ -280,6 +283,7 @@ func TestGCWithPolicy(t *testing.T) {
 		Versioned: imeta.Versioned{
 			SchemaVersion: 2,
 		},
+		MediaType: ispec.MediaTypeImageIndex,
 		Manifests: []ispec.Descriptor{
 			{
 				MediaType: ispec.MediaTypeImageManifest,

--- a/oci/casext/gc_test.go
+++ b/oci/casext/gc_test.go
@@ -65,7 +65,7 @@ func TestGCWithEmptyIndex(t *testing.T) {
 		t.Fatalf("unable to list blobs: %+v", err)
 	}
 	if len(b) != 0 {
-		t.Fatalf("expected empty blob list after GC")
+		t.Fatalf("expected empty blob list after GC: %#v", b)
 	}
 }
 
@@ -123,13 +123,13 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 			SchemaVersion: 2,
 		},
 		Config: ispec.Descriptor{
-			MediaType: ispec.MediaTypeImageIndex,
+			MediaType: ispec.MediaTypeImageLayer,
 			Digest:    digest,
 			Size:      size,
 		},
 		Layers: []ispec.Descriptor{
 			{
-				MediaType: ispec.MediaTypeImageIndex,
+				MediaType: ispec.MediaTypeImageLayer,
 				Digest:    digest,
 				Size:      size,
 			},
@@ -154,7 +154,7 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 		},
 		Manifests: []ispec.Descriptor{
 			{
-				MediaType: ispec.MediaTypeImageIndex,
+				MediaType: ispec.MediaTypeImageManifest,
 				Digest:    digest,
 				Size:      size,
 			},
@@ -162,6 +162,14 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 	}
 	if err := engine.PutIndex(ctx, idx); err != nil {
 		t.Fatalf("error writing index: %+v", err)
+	}
+
+	b, err = engine.ListBlobs(ctx)
+	if err != nil {
+		t.Fatalf("unable to list blobs: %+v", err)
+	}
+	if len(b) <= 2 {
+		t.Fatalf("expected >2 blob list before GC: %#v", b)
 	}
 
 	err = engineExt.GC(ctx)
@@ -173,8 +181,8 @@ func TestGCWithNonEmptyIndex(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to list blobs: %+v", err)
 	}
-	if len(b) != 1 {
-		t.Fatalf("expected single-entry blob list after GC")
+	if len(b) != 2 {
+		t.Fatalf("expected two-entry blob list after GC: %#v", b)
 	}
 }
 
@@ -300,7 +308,7 @@ func TestGCWithPolicy(t *testing.T) {
 		t.Fatalf("unable to list blobs: %+v", err)
 	}
 	if len(b) != 3 {
-		t.Fatalf("expected all entries in blob list after skip GC policy")
+		t.Fatalf("expected all entries in blob list after skip GC policy: %#v", b)
 	}
 
 	err = engineExt.GC(ctx, gcOkFunc(t, odigest, digest))
@@ -314,6 +322,6 @@ func TestGCWithPolicy(t *testing.T) {
 		t.Fatalf("unable to list blobs: %+v", err)
 	}
 	if len(b) != 2 {
-		t.Fatalf("expected blob list with two entries after GC")
+		t.Fatalf("expected blob list with two entries after GC: %#v", b)
 	}
 }

--- a/oci/casext/map_test.go
+++ b/oci/casext/map_test.go
@@ -97,7 +97,8 @@ func TestMapDescriptors_Identity(t *testing.T) {
 		{
 			num: 7,
 			obj: ispec.Manifest{
-				Config: randomDescriptor(t),
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    randomDescriptor(t),
 				Layers: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),
@@ -111,6 +112,7 @@ func TestMapDescriptors_Identity(t *testing.T) {
 		{
 			num: 2,
 			obj: ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),
@@ -121,7 +123,8 @@ func TestMapDescriptors_Identity(t *testing.T) {
 		{
 			num: 5,
 			obj: &ispec.Manifest{
-				Config: randomDescriptor(t),
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    randomDescriptor(t),
 				Layers: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),
@@ -133,6 +136,7 @@ func TestMapDescriptors_Identity(t *testing.T) {
 		{
 			num: 9,
 			obj: &ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),
@@ -154,13 +158,15 @@ func TestMapDescriptors_Identity(t *testing.T) {
 		{
 			num: 1,
 			obj: ispec.Manifest{
-				Config: randomDescriptor(t),
-				Layers: nil,
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    randomDescriptor(t),
+				Layers:    nil,
 			},
 		},
 		{
 			num: 0,
 			obj: ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{},
 			},
 		},
@@ -226,7 +232,8 @@ func TestMapDescriptors_ModifyOCI(t *testing.T) {
 		// Make sure official OCI structs work.
 		{
 			obj: &ispec.Manifest{
-				Config: randomDescriptor(t),
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    randomDescriptor(t),
 				Layers: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),
@@ -239,6 +246,7 @@ func TestMapDescriptors_ModifyOCI(t *testing.T) {
 		},
 		{
 			obj: ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),
@@ -247,6 +255,7 @@ func TestMapDescriptors_ModifyOCI(t *testing.T) {
 		},
 		{
 			obj: &ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{
 					randomDescriptor(t),
 					randomDescriptor(t),

--- a/oci/casext/refname_dir_test.go
+++ b/oci/casext/refname_dir_test.go
@@ -153,7 +153,8 @@ func fakeSetupEngine(t *testing.T, engineExt Engine) ([]descriptorMap, error) {
 			Versioned: ispecs.Versioned{
 				SchemaVersion: 2,
 			},
-			Config: configDescriptor,
+			MediaType: ispec.MediaTypeImageManifest,
+			Config:    configDescriptor,
 		}
 		for _, layer := range layerDescriptors {
 			manifest.Layers = append(manifest.Layers, layer)
@@ -179,6 +180,7 @@ func fakeSetupEngine(t *testing.T, engineExt Engine) ([]descriptorMap, error) {
 				Versioned: ispecs.Versioned{
 					SchemaVersion: 2,
 				},
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{indexDescriptor},
 			}
 			indexDigest, indexSize, err := engineExt.PutBlobJSON(ctx, newIndex)
@@ -278,6 +280,7 @@ func fakeSetupEngine(t *testing.T, engineExt Engine) ([]descriptorMap, error) {
 				Versioned: ispecs.Versioned{
 					SchemaVersion: 2,
 				},
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{indexDescriptor},
 			}
 			indexDigest, indexSize, err := engineExt.PutBlobJSON(ctx, newIndex)
@@ -329,6 +332,7 @@ func fakeSetupEngine(t *testing.T, engineExt Engine) ([]descriptorMap, error) {
 				Versioned: ispecs.Versioned{
 					SchemaVersion: 2,
 				},
+				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{indexDescriptor},
 			}
 			indexDigest, indexSize, err := engineExt.PutBlobJSON(ctx, newIndex)

--- a/oci/layer/layer_fuzzer.go
+++ b/oci/layer/layer_fuzzer.go
@@ -281,8 +281,9 @@ func makeImage(base641, base642 string) (string, ispec.Manifest, casext.Engine, 
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		Config: configDescriptor,
-		Layers: layerDescriptors,
+		MediaType: ispec.MediaTypeImageManifest,
+		Config:    configDescriptor,
+		Layers:    layerDescriptors,
 	}
 
 	return root, manifest, engineExt, nil

--- a/oci/layer/unpack_test.go
+++ b/oci/layer/unpack_test.go
@@ -137,8 +137,9 @@ yRAbACGEEEIIIYQQQgghhBBCCKEr+wTE0sQyACgAAA==`,
 		Versioned: specs.Versioned{
 			SchemaVersion: 2,
 		},
-		Config: configDescriptor,
-		Layers: layerDescriptors,
+		MediaType: ispec.MediaTypeImageManifest,
+		Config:    configDescriptor,
+		Layers:    layerDescriptors,
 	}
 
 	return root, manifest, engineExt

--- a/test/create.bats
+++ b/test/create.bats
@@ -277,8 +277,8 @@ function teardown() {
 	# Verify that the hashes of the blobs and index match (blobs are
 	# content-addressable so using hashes is a bit silly, but whatever).
 	known_hashes=(
-		"4e15e3699a98dddc67cb2e9aa5a6135cdf8ffcbdc7963daf959395f73dd52849  $IMAGE/index.json"
-		"54d5cbf998d9b1185628128d83af76ca18425f037ef9f79e6900f7e26985c169  $IMAGE/blobs/sha256/54d5cbf998d9b1185628128d83af76ca18425f037ef9f79e6900f7e26985c169"
+		"6f3716b8ae2bb4b3fd0a851f5a553946ea351ed5fdda0bd708d325363c0487f7  $IMAGE/index.json"
+		"73ecb862d0ebee78acdf8553d34d1ae5c13df509030ac262e561d096bb480dfc  $IMAGE/blobs/sha256/73ecb862d0ebee78acdf8553d34d1ae5c13df509030ac262e561d096bb480dfc"
 		"e7013826daf8b5d68f82c5b790ca5e9de222a834f2cb3fe3532030161bd72083  $IMAGE/blobs/sha256/e7013826daf8b5d68f82c5b790ca5e9de222a834f2cb3fe3532030161bd72083"
 		"f4a39a97d97aa834da7ad2d92940f9636a57e3d9b3cc7c53242451b02a6cea89  $IMAGE/blobs/sha256/f4a39a97d97aa834da7ad2d92940f9636a57e3d9b3cc7c53242451b02a6cea89"
 	)


### PR DESCRIPTION
Ensure that we never permit an ambigous blob (one that can be either a
manifest or index) and make sure we set and check the now-defined
MediaType field whenever parsing such blobs.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>