### PR TITLE
pkg: turn down verified reader's complaints

### DIFF
--- a/pkg/hardening/verified_reader.go
+++ b/pkg/hardening/verified_reader.go
@@ -188,7 +188,7 @@ func (v *VerifiedReadCloser) Close() error {
 		// If there's trailing bytes being discarded at this point, that
 		// indicates whatever you used to generate this blob is adding trailing
 		// gunk.
-		log.Infof("verified reader: %d bytes of trailing data discarded from %s", n, v.sourceName())
+		log.Debugf("verified reader: %d bytes of trailing data discarded from %s", n, v.sourceName())
 	}
 	// Piped to underlying close.
 	err := v.Reader.Close()


### PR DESCRIPTION
Simply traversing an image can yield:

  INFO[0001] verified reader: 116572160 bytes of trailing data discarded from vrdr[...]
  INFO[0002] verified reader: 116948992 bytes of trailing data discarded from vrdr[...]

Let's make this a debug so it generates less noise.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>