### PR TITLE
fuzz: always use golang:latest

### DIFF
--- a/Dockerfile.fuzz
+++ b/Dockerfile.fuzz
@@ -1,4 +1,4 @@
-FROM golang:1.17.5
+FROM golang:latest
 
 RUN apt-get update && apt-get install -y clang
 


### PR DESCRIPTION
Go is backwards compatible, so it makes more sense to just use the
latest version rather than pinning a version which we need to update
with dependabot regularly.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>