### PR TITLE
mutator: allow setting annotation data when generating a layer

### DIFF
--- a/cmd/umoci/insert.go
+++ b/cmd/umoci/insert.go
@@ -190,7 +190,7 @@ func insert(ctx *cli.Context) error {
 
 	// TODO: We should add a flag to allow for a new layer to be made
 	//       non-distributable.
-	if _, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, reader, history, mutate.GzipCompressor); err != nil {
+	if _, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, reader, history, mutate.GzipCompressor, nil); err != nil {
 		return errors.Wrap(err, "add diff layer")
 	}
 

--- a/cmd/umoci/raw-add-layer.go
+++ b/cmd/umoci/raw-add-layer.go
@@ -155,7 +155,7 @@ func rawAddLayer(ctx *cli.Context) error {
 
 	// TODO: We should add a flag to allow for a new layer to be made
 	//       non-distributable.
-	if _, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, newLayer, history, mutate.GzipCompressor); err != nil {
+	if _, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, newLayer, history, mutate.GzipCompressor, nil); err != nil {
 		return errors.Wrap(err, "add diff layer")
 	}
 

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -279,7 +279,7 @@ func (m *Mutator) add(ctx context.Context, reader io.Reader, history *ispec.Hist
 // generate the DiffIDs for the image metatadata. The provided history entry is
 // appended to the image's history and should correspond to what operations
 // were made to the configuration.
-func (m *Mutator) Add(ctx context.Context, mediaType string, r io.Reader, history *ispec.History, compressor Compressor) (ispec.Descriptor, error) {
+func (m *Mutator) Add(ctx context.Context, mediaType string, r io.Reader, history *ispec.History, compressor Compressor, annotations map[string]string) (ispec.Descriptor, error) {
 	desc := ispec.Descriptor{}
 	if err := m.cache(ctx); err != nil {
 		return desc, errors.Wrap(err, "getting cache failed")
@@ -297,9 +297,10 @@ func (m *Mutator) Add(ctx context.Context, mediaType string, r io.Reader, histor
 
 	// Append to layers.
 	desc = ispec.Descriptor{
-		MediaType: compressedMediaType,
-		Digest:    digest,
-		Size:      size,
+		MediaType:   compressedMediaType,
+		Digest:      digest,
+		Size:        size,
+		Annotations: annotations,
 	}
 	m.manifest.Layers = append(m.manifest.Layers, desc)
 	return desc, nil

--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -216,9 +216,10 @@ func TestMutateAdd(t *testing.T) {
 	buffer := bytes.NewBufferString("contents")
 
 	// Add a new layer.
+	annotations := map[string]string{"hello": "world"}
 	newLayerDesc, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, buffer, &ispec.History{
 		Comment: "new layer",
-	}, GzipCompressor)
+	}, GzipCompressor, annotations)
 	if err != nil {
 		t.Fatalf("unexpected error adding layer: %+v", err)
 	}
@@ -251,6 +252,9 @@ func TestMutateAdd(t *testing.T) {
 	}
 	if mutator.manifest.Layers[1].Digest == expectedLayerDigest {
 		t.Errorf("manifest.Layers[1].Digest is not the same!")
+	}
+	if len(mutator.manifest.Layers[1].Annotations) != 1 || mutator.manifest.Layers[1].Annotations["hello"] != "world" {
+		t.Errorf("manifest.Layers[1].Annotations was not set correctly!")
 	}
 
 	if mutator.manifest.Layers[1].Digest != newLayerDesc.Digest {
@@ -312,7 +316,7 @@ func TestMutateAddExisting(t *testing.T) {
 	// Add a new layer.
 	_, err = mutator.Add(context.Background(), ispec.MediaTypeImageLayer, buffer, &ispec.History{
 		Comment: "new layer",
-	}, GzipCompressor)
+	}, GzipCompressor, nil)
 	if err != nil {
 		t.Fatalf("unexpected error adding layer: %+v", err)
 	}

--- a/repack.go
+++ b/repack.go
@@ -114,7 +114,7 @@ func Repack(engineExt casext.Engine, tagName string, bundlePath string, meta Met
 
 		// TODO: We should add a flag to allow for a new layer to be made
 		//       non-distributable.
-		if _, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, reader, history, mutate.GzipCompressor); err != nil {
+		if _, err := mutator.Add(context.Background(), ispec.MediaTypeImageLayer, reader, history, mutate.GzipCompressor, nil); err != nil {
 			return errors.Wrap(err, "add diff layer")
 		}
 	}


### PR DESCRIPTION
We want to include some additional hash data in the annotations when
generating layers, so let's allow setting this.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>