### PR TITLE
*: io.Copy improvements

### DIFF
--- a/mutate/compress.go
+++ b/mutate/compress.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"runtime"
 
+	"github.com/apex/log"
 	zstd "github.com/klauspost/compress/zstd"
 	gzip "github.com/klauspost/pgzip"
 	"github.com/opencontainers/umoci/pkg/system"
@@ -50,16 +51,21 @@ func (gz gzipCompressor) Compress(reader io.Reader) (io.ReadCloser, error) {
 	}
 	go func() {
 		if _, err := system.Copy(gzw, reader); err != nil {
+			log.Warnf("gzip compress: could not compress layer: %v", err)
 			// #nosec G104
 			_ = pipeWriter.CloseWithError(errors.Wrap(err, "compressing layer"))
+			return
 		}
 		if err := gzw.Close(); err != nil {
+			log.Warnf("gzip compress: could not close gzip writer: %v", err)
 			// #nosec G104
 			_ = pipeWriter.CloseWithError(errors.Wrap(err, "close gzip writer"))
+			return
 		}
 		if err := pipeWriter.Close(); err != nil {
-			// #nosec G104
-			_ = pipeWriter.CloseWithError(errors.Wrap(err, "close pipe writer"))
+			log.Warnf("gzip compress: could not close pipe: %v", err)
+			// We don't CloseWithError because we cannot override the Close.
+			return
 		}
 	}()
 
@@ -78,22 +84,27 @@ type zstdCompressor struct{}
 func (zs zstdCompressor) Compress(reader io.Reader) (io.ReadCloser, error) {
 
 	pipeReader, pipeWriter := io.Pipe()
-	zenc, err := zstd.NewWriter(pipeWriter)
+	zw, err := zstd.NewWriter(pipeWriter)
 	if err != nil {
 		return nil, err
 	}
 	go func() {
-		if _, err := system.Copy(zenc, reader); err != nil {
+		if _, err := system.Copy(zw, reader); err != nil {
+			log.Warnf("zstd compress: could not compress layer: %v", err)
 			// #nosec G104
 			_ = pipeWriter.CloseWithError(errors.Wrap(err, "compressing layer"))
+			return
 		}
-		if err := zenc.Close(); err != nil {
+		if err := zw.Close(); err != nil {
+			log.Warnf("zstd compress: could not close gzip writer: %v", err)
 			// #nosec G104
-			_ = pipeWriter.CloseWithError(errors.Wrap(err, "close gzip writer"))
+			_ = pipeWriter.CloseWithError(errors.Wrap(err, "close zstd writer"))
+			return
 		}
 		if err := pipeWriter.Close(); err != nil {
-			// #nosec G104
-			_ = pipeWriter.CloseWithError(errors.Wrap(err, "close pipe writer"))
+			log.Warnf("zstd compress: could not close pipe: %v", err)
+			// We don't CloseWithError because we cannot override the Close.
+			return
 		}
 	}()
 

--- a/mutate/compress.go
+++ b/mutate/compress.go
@@ -7,6 +7,7 @@ import (
 
 	zstd "github.com/klauspost/compress/zstd"
 	gzip "github.com/klauspost/pgzip"
+	"github.com/opencontainers/umoci/pkg/system"
 	"github.com/pkg/errors"
 )
 
@@ -48,7 +49,7 @@ func (gz gzipCompressor) Compress(reader io.Reader) (io.ReadCloser, error) {
 		return nil, errors.Wrapf(err, "set concurrency level to %v blocks", 2*runtime.NumCPU())
 	}
 	go func() {
-		if _, err := io.Copy(gzw, reader); err != nil {
+		if _, err := system.Copy(gzw, reader); err != nil {
 			// #nosec G104
 			_ = pipeWriter.CloseWithError(errors.Wrap(err, "compressing layer"))
 		}
@@ -82,7 +83,7 @@ func (zs zstdCompressor) Compress(reader io.Reader) (io.ReadCloser, error) {
 		return nil, err
 	}
 	go func() {
-		if _, err := io.Copy(zenc, reader); err != nil {
+		if _, err := system.Copy(zenc, reader); err != nil {
 			// #nosec G104
 			_ = pipeWriter.CloseWithError(errors.Wrap(err, "compressing layer"))
 		}

--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -31,6 +31,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci/oci/cas"
 	"github.com/opencontainers/umoci/pkg/hardening"
+	"github.com/opencontainers/umoci/pkg/system"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -167,7 +168,7 @@ func (e *dirEngine) PutBlob(ctx context.Context, reader io.Reader) (digest.Diges
 	defer fh.Close()
 
 	writer := io.MultiWriter(fh, digester.Hash())
-	size, err := io.Copy(writer, reader)
+	size, err := system.Copy(writer, reader)
 	if err != nil {
 		return "", -1, errors.Wrap(err, "copy to temporary blob")
 	}

--- a/oci/casext/blob.go
+++ b/oci/casext/blob.go
@@ -24,6 +24,7 @@ import (
 
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci/oci/casext/mediatype"
+	"github.com/opencontainers/umoci/pkg/system"
 	"github.com/pkg/errors"
 )
 
@@ -72,7 +73,7 @@ func (e Engine) FromDescriptor(ctx context.Context, descriptor ispec.Descriptor)
 
 	if fn := mediatype.GetParser(descriptor.MediaType); fn != nil {
 		defer func() {
-			if _, err := io.Copy(ioutil.Discard, reader); Err == nil {
+			if _, err := system.Copy(ioutil.Discard, reader); Err == nil {
 				Err = errors.Wrapf(err, "discard trailing %q blob", descriptor.MediaType)
 			}
 			if err := reader.Close(); Err == nil {

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -54,6 +54,7 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 	go func() (Err error) {
 		// Close with the returned error.
 		defer func() {
+			log.Warnf("could not generate layer: %v", Err)
 			// #nosec G104
 			_ = writer.CloseWithError(errors.Wrap(Err, "generate layer"))
 		}()
@@ -134,8 +135,9 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 
 	go func() (Err error) {
 		defer func() {
+			log.Warnf("could not generate insert layer: %v", Err)
 			// #nosec G104
-			_ = writer.CloseWithError(errors.Wrap(Err, "generate layer"))
+			_ = writer.CloseWithError(errors.Wrap(Err, "generate insert layer"))
 		}()
 
 		tg := newTarGenerator(writer, packOptions.MapOptions)

--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -573,7 +573,7 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 		defer fh.Close()
 
 		// We need to make sure that we copy all of the bytes.
-		n, err := io.Copy(fh, r)
+		n, err := system.Copy(fh, r)
 		if int64(n) != hdr.Size {
 			if err != nil {
 				err = errors.Wrapf(err, "short write")

--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/opencontainers/umoci/pkg/fseval"
+	"github.com/opencontainers/umoci/pkg/system"
 	"github.com/opencontainers/umoci/pkg/testutils"
 	"github.com/pkg/errors"
 )
@@ -259,7 +260,7 @@ func (tg *tarGenerator) AddFile(name, path string) error {
 		}
 		defer fh.Close()
 
-		n, err := io.Copy(tg.tw, fh)
+		n, err := system.Copy(tg.tw, fh)
 		if err != nil {
 			return errors.Wrap(err, "copy to layer")
 		}

--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -274,7 +274,7 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 		// in the later diff_id check failing because the digester didn't get
 		// the whole uncompressed stream). Just blindly consume anything left
 		// in the layer.
-		if n, err := io.Copy(ioutil.Discard, layer); err != nil {
+		if n, err := system.Copy(ioutil.Discard, layer); err != nil {
 			return errors.Wrap(err, "discard trailing archive bits")
 		} else if n != 0 {
 			log.Debugf("unpack manifest: layer %s: ignoring %d trailing 'junk' bytes in the tar stream -- probably from GNU tar", layerDescriptor.Digest, n)
@@ -284,9 +284,9 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 		// Just eat up the rest of the remaining bytes and discard them.
 		//
 		// FIXME: We use layerData here because pgzip returns io.EOF from
-		// WriteTo, which causes havoc with io.Copy. Ideally we would use
+		// WriteTo, which causes havoc with system.Copy. Ideally we would use
 		// layerRaw. See <https://github.com/klauspost/pgzip/issues/38>.
-		if n, err := io.Copy(ioutil.Discard, layerData); err != nil {
+		if n, err := system.Copy(ioutil.Discard, layerData); err != nil {
 			return errors.Wrap(err, "discard trailing raw bits")
 		} else if n != 0 {
 			log.Warnf("unpack manifest: layer %s: ignoring %d trailing 'junk' bytes in the blob stream -- this may indicate a bug in the tool which built this image", layerDescriptor.Digest, n)

--- a/pkg/hardening/verified_reader.go
+++ b/pkg/hardening/verified_reader.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/umoci/pkg/system"
 	"github.com/pkg/errors"
 )
 
@@ -182,7 +183,7 @@ func (v *VerifiedReadCloser) Close() error {
 	// Consume any remaining bytes to make sure that we've actually read to the
 	// end of the stream. VerifiedReadCloser.Read will not read past
 	// ExpectedSize+1, so we don't need to add a limit here.
-	if n, err := io.Copy(ioutil.Discard, v); err != nil {
+	if n, err := system.Copy(ioutil.Discard, v); err != nil {
 		return errors.Wrap(err, "consume remaining unverified stream")
 	} else if n != 0 {
 		// If there's trailing bytes being discarded at this point, that

--- a/pkg/system/copy.go
+++ b/pkg/system/copy.go
@@ -1,0 +1,65 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2022 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package system
+
+import (
+	"errors"
+	"io"
+
+	"golang.org/x/sys/unix"
+)
+
+// Copy has identical semantics to io.Copy except it will automatically resume
+// the copy after it receives an EINTR error.
+func Copy(dst io.Writer, src io.Reader) (int64, error) {
+	// Make a buffer so io.Copy doesn't make one for each iteration.
+	var buf []byte
+	size := 32 * 1024
+	if lr, ok := src.(*io.LimitedReader); ok && lr.N < int64(size) {
+		if lr.N < 1 {
+			size = 1
+		} else {
+			size = int(lr.N)
+		}
+	}
+	buf = make([]byte, size)
+
+	var written int64
+	for {
+		n, err := io.CopyBuffer(dst, src, buf)
+		written += n // n is always non-negative
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		return written, err
+	}
+}
+
+// CopyN has identical semantics to io.CopyN except it will automatically
+// resume the copy after it receives an EINTR error.
+func CopyN(dst io.Writer, src io.Reader, n int64) (written int64, err error) {
+	// This is based on the stdlib io.CopyN implementation.
+	written, err = Copy(dst, io.LimitReader(src, n))
+	if written == n {
+		err = nil // somewhat confusing io.CopyN semantics
+	}
+	if written < n && err == nil {
+		err = io.EOF // if the source ends prematurely, io.EOF
+	}
+	return
+}


### PR DESCRIPTION
* Implement EINTR-retry logic for `io.Copy` users to avoid erroring out for no reason.
* Improve io.Pipe CloseWithError usage so that we make any pipe-passed errors louder.

These changes might help with #436 but I'm not sure whether these were the root cause of the issue.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>