### PR TITLE
fuzzing: Add ClusterfuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,4 @@
+FROM gcr.io/oss-fuzz-base/base-builder-go
+COPY . $SRC/
+WORKDIR umoci
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+go mod tidy && go mod vendor
+go get github.com/AdaLogics/go-fuzz-headers@latest
+go mod vendor
+
+compile_go_fuzzer github.com/opencontainers/umoci/oci/casext Fuzz casext_fuzz
+compile_go_fuzzer github.com/opencontainers/umoci/oci/layer FuzzUnpack fuzz_unpack
+compile_go_fuzzer github.com/opencontainers/umoci/oci/layer FuzzGenerateLayer fuzz_generate_layer
+compile_go_fuzzer github.com/opencontainers/umoci/mutate FuzzMutate fuzz_mutate
+compile_go_fuzzer github.com/opencontainers/umoci/pkg/hardening Fuzz fuzz_hardening
+
+

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: go

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,29 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**'
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: go
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 400
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}

--- a/mutate/mutate_fuzzer.go
+++ b/mutate/mutate_fuzzer.go
@@ -148,16 +148,22 @@ func FuzzMutate(data []byte) int {
 	}
 
 	// This isn't a valid image, but whatever.
-	fuzzedString, err := c.GetString()
+	fuzzedBytes, err := c.GetBytes()
 	if err != nil {
 		return -1
 	}
-	buffer := bytes.NewBufferString(fuzzedString)
+	buffer := bytes.NewReader(fuzzedBytes)
+
+	m := make(map[string]string)
+	err = c.FuzzMap(&m)
+	if err != nil {
+		return 0
+	}
 
 	// Add a new layer.
 	_, err = mutator.Add(context.Background(), ispec.MediaTypeImageLayer, buffer, &ispec.History{
 		Comment: "new layer",
-	}, GzipCompressor)
+	}, GzipCompressor, m)
 	if err != nil {
 		return 0
 	}

--- a/oci/layer/layer_fuzzer.go
+++ b/oci/layer/layer_fuzzer.go
@@ -333,9 +333,7 @@ func FuzzUnpack(data []byte) int {
 		Rootless: os.Geteuid() != 0,
 	}}
 
-	called := false
 	unpackOptions.AfterLayerUnpack = func(m ispec.Manifest, d ispec.Descriptor) error {
-		called = true
 		return nil
 	}
 


### PR DESCRIPTION
Sets up [ClusterfuzzLite](https://google.github.io/clusterfuzzlite/) which will run the fuzzers in the CI. 

ClusterfuzzLite can also be set up to perform [batch fuzzing](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) which runs the fuzzers regularly and stores the corpus.

Also fixes the fuzzers.

Signed-off-by: AdamKorcz <Adam@adalogics.com>
