### PR TITLE
oci: casext: mediatype: switch to generics for parser functions

### DIFF
--- a/oci/casext/refname_dir_test.go
+++ b/oci/casext/refname_dir_test.go
@@ -53,7 +53,7 @@ type fakeManifest struct {
 }
 
 func init() {
-	fakeManifestParser := mediatype.CustomJSONParser(fakeManifest{})
+	fakeManifestParser := mediatype.JSONParser[fakeManifest]
 
 	mediatype.RegisterParser(customMediaType, fakeManifestParser)
 	mediatype.RegisterTarget(customTargetMediaType)


### PR DESCRIPTION
We cannot use generics for the parser function map, but we can use it when instantiating "simple" JSON parser functions. There are a few other downsides to Go's generics, so this should just be a minor (possibly even theoretical) performance improvement over constructing the parsed types using reflection.