### PR TITLE
Do not chmod +r if we don't need to

### DIFF
--- a/pkg/unpriv/unpriv.go
+++ b/pkg/unpriv/unpriv.go
@@ -129,11 +129,13 @@ func Open(path string) (*os.File, error) {
 			return errors.Wrap(err, "lstat file")
 		}
 
-		// Add +r permissions to the file.
-		if err := os.Chmod(path, fi.Mode()|0400); err != nil {
-			return errors.Wrap(err, "chmod +r")
+		if fi.Mode()&0400 != 0400 {
+			// Add +r permissions to the file.
+			if err := os.Chmod(path, fi.Mode()|0400); err != nil {
+				return errors.Wrap(err, "chmod +r")
+			}
+			defer fiRestore(path, fi)
 		}
-		defer fiRestore(path, fi)
 
 		// Open the damn thing.
 		fh, err = os.Open(path)


### PR DESCRIPTION
If the inode is a mountpoint, chmod may just fail.

(See https://github.com/project-stacker/stacker/issues/450)