### PR TITLE
fix(gzip): change compression block size

### DIFF
--- a/mutate/compress.go
+++ b/mutate/compress.go
@@ -46,7 +46,7 @@ func (gz gzipCompressor) Compress(reader io.Reader) (io.ReadCloser, error) {
 	pipeReader, pipeWriter := io.Pipe()
 
 	gzw := gzip.NewWriter(pipeWriter)
-	if err := gzw.SetConcurrency(256<<10, 2*runtime.NumCPU()); err != nil {
+	if err := gzw.SetConcurrency(256<<12, 2*runtime.NumCPU()); err != nil {
 		return nil, errors.Wrapf(err, "set concurrency level to %v blocks", 2*runtime.NumCPU())
 	}
 	go func() {


### PR DESCRIPTION
Several tools set this as the default value.

image/copy/copy.go
56:var compressionBufferSize = 1048576

skopeo/vendor/github.com/containers/image/v5/copy/compression.go
24:     compressionBufferSize = 1048576

Choosing a different value causes the final gzip'ed layer to become different although the source tar is identical, causing an content-addressable invariants to break.