### PR TITLE
release: build binaries for common architectures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,18 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v5
+      - run: make release
+      - name: upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-${{ github.run_id }}
+          path: release/*
+
   validate:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,9 @@ umoci.cover: $(GO_SRC)
 
 .PHONY: release
 release:
-	hack/release.sh -v $(VERSION) -S "$(GPG_KEYID)"
+	hack/release.sh \
+		-a 386 -a amd64 -a arm64 -a ppc64le -a riscv64 -a s390x \
+		-v $(VERSION) -S "$(GPG_KEYID)"
 
 .PHONY: install
 install: umoci docs


### PR DESCRIPTION
For now, just build binaries for Linux. We do have integration tests for
MacOS/darwin, but I'm not sure if I'm comfortable saying we support
those architectures enough to release binaries for them.

Fixes #505
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>