### PR TITLE
fix a Sirupsen/logrus import issue in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN zypper -n in \
 		curl \
 		git \
 		gnu_parallel \
-		"go>=1.18" \
+		"go==1.21" \
 		go-mtree \
 		gzip \
 		jq \


### PR DESCRIPTION
we are seeing:

2.947 go: github.com/opencontainers/image-tools/cmd/oci-image-tool imports
2.947 	github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.9.3: parsing go.mod:
2.947 	module declares its path as: github.com/sirupsen/logrus
2.947 	        but was required as: github.com/Sirupsen/logrus

in CI, hopefully this replace fixes it?