### PR TITLE
generateinsertlayer: ensure that we close the tarwriter

### DIFF
--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -54,7 +54,9 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 	go func() (Err error) {
 		// Close with the returned error.
 		defer func() {
-			log.Warnf("could not generate layer: %v", Err)
+			if Err != nil {
+				log.Warnf("could not generate layer: %v", Err)
+			}
 			// #nosec G104
 			_ = writer.CloseWithError(errors.Wrap(Err, "generate layer"))
 		}()
@@ -135,7 +137,9 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 
 	go func() (Err error) {
 		defer func() {
-			log.Warnf("could not generate insert layer: %v", Err)
+			if Err != nil {
+				log.Warnf("could not generate insert layer: %v", Err)
+			}
 			// #nosec G104
 			_ = writer.CloseWithError(errors.Wrap(Err, "generate insert layer"))
 		}()

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -142,6 +142,12 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 
 		tg := newTarGenerator(writer, packOptions.MapOptions)
 
+		defer func() {
+			if err := tg.tw.Close(); err != nil {
+				log.Warnf("generate insert layer: could not close tar.Writer: %s", err)
+			}
+		}()
+
 		if opaque {
 			if err := tg.AddOpaqueWhiteout(target); err != nil {
 				return err

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -45,6 +45,7 @@ function teardown() {
 	touch "${INSERTDIR}/test/a"
 	touch "${INSERTDIR}/test/b"
 	chmod +x "${INSERTDIR}/test/b"
+	echo "foo" > "${INSERTDIR}/test/smallfile"
 
 	# Make sure rootless mode works.
 	mkdir -p "${INSERTDIR}/some/path"
@@ -65,6 +66,10 @@ function teardown() {
 	image-verify "${IMAGE}"
 
 	umoci insert --image "${IMAGE}:${TAG}" --tag "${TAG}-new" "${INSERTDIR}/some" /rootless
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	umoci insert --image "${IMAGE}:${TAG}" "${INSERTDIR}/test/smallfile" /tester/smallfile
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 


### PR DESCRIPTION
This fixes #436.

I added a test that shows the issue - the commit with the fix has the full explanation, repeated here:



generatelayer closes the tarwriter, but generateinsertlayer forgets to.

Closing the tarwriter writes the required footer of 1k of zeros.

This results in tar files that are complete but invalid, and different
reading tools will behave differently:

- bsdtar doesn't complain and exits 0
- gnu tar (and security scanning tools that use it) will exit 2 with an
unexpected EOF message
- python's tarfile library will raise an Unexpected EOF error
- golang's archive/tar library can raise an unexpected EOF error, but
  for some files created by generateinsertlayer, it just raises a
  plain EOF error, which means golang based tools generally ignore this
  and work fine, this includes umoci.
