### PR TITLE
layer: numerous overlayfs whiteout fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   #452
 - umoci will now return an explicit error if you pass invalid uid or gid values
   to `--uid-map` and `--gid-map` rather than silently truncating the value.
+- For Go users of umoci, `GenerateLayer` (but not `GenerateInsertLayer`) with
+  the `TranslateOverlayWhiteouts` option enabled had several severe bugs that
+  made the feature unusable:
+  * All OCI whiteouts added to the archive would incorrectly have the full host
+    name of the path rather than the correctly rooted path, making the whiteout
+    practically useless.
 
 ## [0.4.7] - 2021-04-05 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     `--compress` flag. You can also disable compression entirely using
     `--compress=none` but `--compress=auto` will never automatically choose
     `none` compression.
+- `GenerateLayer` and `GenerateInsertLayer` with `TranslateOverlayWhiteouts`
+  now support converting `trusted.overlay.opaque=y` and
+  `trusted.overlay.whiteout` whiteouts into OCI whiteouts when generating OCI
+  layers.
 
 ### Changes ###
 - In this release, the primary development branch was renamed to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Given how severe these bugs were and the lack of bug reports of this issue in
   the past 4 years, it seems this feature has not really been used by anyone (I
   hope...).
+- For Go users of umoci, `UnpackLayer` now correctly handles several aspects of
+  `OverlayFSWhiteout` extraction that weren't handled correctly:
+  * Unlike regular extractions, overlayfs-style extractions require us to
+    create the parent directory of the whiteout (rather than ignoring or
+    assuming the underlying path exists) because the whiteout is being created
+    in a separate layer to the underlying file. We also need to make sure that
+    opaque whiteout targets are directories.
 
 ## [0.4.7] - 2021-04-05 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     extract plain whiteouts within an opaque whiteout directory in the same
     layer. (As per the OCI spec requirements, this is regardless of the order
     of the opaque whiteout and the regular whiteout in the layer archive.)
+- `UnpackLayer` and `Generate(Insert)Layer` now correctly handle
+  `trusted.overlay.*` xattr escaping when extracting and generating layers with
+  the overlayfs on-disk format. This escaping feature [has been supported by
+  overlayfs since Linux 6.7][linux-overlayfs-escaping-dad02fad84cbc], and
+  allows for you to created images that contain an overlayfs layout inside the
+  image (nested to arbitrary levels).
+  * If an image contains `trusted.overlay.*` xattrs, `UnpackLayer` will
+    rewrite the xattrs to instead be in the `trusted.overlay.overlay.*`
+    namespace, so that when merged using overlayfs the user will see the
+    expected xattrs.
+  * If an on-disk overlayfs directory used with `Generate(Insert)Layer`
+    contains escaped `trusted.overlay.overlay.*` xattrs, they will be rewritten
+    so that the generated layer contains `trusted.overlay.*` xattrs. If we
+    encounter an unescaped `trusted.overlay.*` xattr they will not be included
+    in the image (though they may cause the file to be converted to a whiteout
+    in the image) because they are considered to be an internal aspect of the
+    host on-disk format (i.e. `trusted.overlay.origin` might be automatically
+    set by whatever tool is using the overlayfs layers).
+  Note that in the regular extraction mode, these xattrs will be treated like
+  any other xattrs (this is in contrast to the previous behaviour where they
+  would be silently ignored regardless of the on-disk format being used).
+
+[linux-overlayfs-escaping-dad02fad84cbc]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dad02fad84cbce30f317b69a4f2391f90045f79d
 
 ## [0.4.7] - 2021-04-05 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     assuming the underlying path exists) because the whiteout is being created
     in a separate layer to the underlying file. We also need to make sure that
     opaque whiteout targets are directories.
+  * `trusted.overlay.opaque=y` has very peculiar behaviour when a regular
+    whiteout (i.e. `mknod c 0 0`) is placed inside an opaque directory -- the
+    whiteout-ed file appears in `readdir` but the file itself doesn't exist. To
+    avoid this confusion (and possible information leak), umoci will no longer
+    extract plain whiteouts within an opaque whiteout directory in the same
+    layer. (As per the OCI spec requirements, this is regardless of the order
+    of the opaque whiteout and the regular whiteout in the layer archive.)
 
 ## [0.4.7] - 2021-04-05 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   * All OCI whiteouts added to the archive would incorrectly have the full host
     name of the path rather than the correctly rooted path, making the whiteout
     practically useless.
+  * Any non-whiteout files would not be included in the layer, making the layer
+    data incomplete and thus resulting in silent data loss.
+  Given how severe these bugs were and the lack of bug reports of this issue in
+  the past 4 years, it seems this feature has not really been used by anyone (I
+  hope...).
 
 ## [0.4.7] - 2021-04-05 ##
 

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -68,7 +68,7 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 		// We can't just dump all of the file contents into a tar file. We need
 		// to emulate a proper tar generator. Luckily there aren't that many
 		// things to emulate (and we can do them all in tar.go).
-		tg := newTarGenerator(writer, packOptions.MapOptions)
+		tg := newTarGenerator(writer, packOptions)
 
 		// Sort the delta paths.
 		// FIXME: We need to add whiteouts first, otherwise we might end up
@@ -150,7 +150,7 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 			_ = writer.CloseWithError(closeErr)
 		}()
 
-		tg := newTarGenerator(writer, packOptions.MapOptions)
+		tg := newTarGenerator(writer, packOptions)
 
 		defer func() {
 			if err := tg.tw.Close(); err != nil {

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -96,7 +96,8 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 						return err
 					}
 					if whiteout {
-						if err := tg.AddWhiteout(fullPath); err != nil {
+						log.Debugf("generate layer: converting overlayfs whiteout %q to OCI whiteout", name)
+						if err := tg.AddWhiteout(name); err != nil {
 							return fmt.Errorf("generate whiteout from overlayfs: %w", err)
 						}
 					}
@@ -181,7 +182,7 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *RepackOpt
 				return err
 			}
 			if packOptions.TranslateOverlayWhiteouts && whiteout {
-				log.Debugf("converting overlayfs whiteout %s to OCI whiteout", name)
+				log.Debugf("generate insert layer: converting overlayfs whiteout %q to OCI whiteout", name)
 				return tg.AddWhiteout(name)
 			}
 

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -28,7 +28,7 @@ import (
 	"github.com/apex/log"
 	"github.com/vbatts/go-mtree"
 
-	"github.com/opencontainers/umoci/pkg/unpriv"
+	"github.com/opencontainers/umoci/pkg/fseval"
 )
 
 // inodeDeltas is a wrapper around []mtree.InodeDelta that allows for sorting
@@ -138,6 +138,10 @@ func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) i
 	if opt != nil {
 		packOptions = *opt
 	}
+	fsEval := fseval.Default
+	if packOptions.MapOptions.Rootless {
+		fsEval = fseval.Rootless
+	}
 
 	reader, writer := io.Pipe()
 
@@ -169,7 +173,7 @@ func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) i
 			}
 			// Continue on to add the new root contents...
 		}
-		return unpriv.Walk(root, func(fullPath string, info os.FileInfo, err error) error {
+		return fsEval.Walk(root, func(fullPath string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -100,8 +100,8 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 						if err := tg.AddWhiteout(name); err != nil {
 							return fmt.Errorf("generate whiteout from overlayfs: %w", err)
 						}
+						continue
 					}
-					continue
 				}
 				if err := tg.AddFile(name, fullPath); err != nil {
 					log.Warnf("generate layer: could not add file %q: %s", name, err)

--- a/oci/layer/generate_linux_test.go
+++ b/oci/layer/generate_linux_test.go
@@ -99,8 +99,11 @@ func TestGenerateLayerTranslateOverlayWhiteouts(t *testing.T) {
 	defer reader.Close()
 
 	tr := tar.NewReader(reader)
-
 	hdr, err := tr.Next()
+	assert.NoError(t, err, "read next header")
+	assert.Equal(t, hdr.Name, ".", "first entry should be /")
+
+	hdr, err = tr.Next()
 	assert.NoError(t, err, "read next header")
 	assert.EqualValues(t, hdr.Typeflag, tar.TypeReg, "whiteout typeflag")
 	assert.Equal(t, hdr.Name, whPrefix+"test", "whiteout pathname prefix")

--- a/oci/layer/generate_linux_test.go
+++ b/oci/layer/generate_linux_test.go
@@ -103,7 +103,7 @@ func TestGenerateLayerTranslateOverlayWhiteouts(t *testing.T) {
 	hdr, err := tr.Next()
 	assert.NoError(t, err, "read next header")
 	assert.EqualValues(t, hdr.Typeflag, tar.TypeReg, "whiteout typeflag")
-	assert.Equal(t, path.Base(hdr.Name), whPrefix+"test", "whiteout pathname prefix")
+	assert.Equal(t, hdr.Name, whPrefix+"test", "whiteout pathname prefix")
 
 	_, err = tr.Next()
 	assert.ErrorIs(t, err, io.EOF, "end of archive")

--- a/oci/layer/generate_linux_test.go
+++ b/oci/layer/generate_linux_test.go
@@ -82,3 +82,103 @@ func TestTranslateOverlayWhiteouts_Char00(t *testing.T) {
 		})
 	})
 }
+
+func TestTranslateOverlayWhiteouts_XattrOpaque(t *testing.T) {
+	dir := t.TempDir()
+
+	testNeedsTrustedOverlayXattrs(t)
+
+	err := os.Mkdir(filepath.Join(dir, "wodir"), 0755)
+	require.NoError(t, err)
+	err = unix.Lsetxattr(filepath.Join(dir, "wodir"), "trusted.overlay.opaque", []byte("y"), 0)
+	require.NoError(t, err, "lsetxattr trusted.overlay.opaque")
+	err = os.WriteFile(filepath.Join(dir, "reg"), []byte("dummy file"), 0644)
+	require.NoError(t, err)
+
+	packOptions := RepackOptions{TranslateOverlayWhiteouts: true}
+
+	t.Run("GenerateLayer", func(t *testing.T) {
+		// something reasonable
+		mtreeKeywords := []mtree.Keyword{
+			"size",
+			"type",
+			"uid",
+			"gid",
+			"mode",
+		}
+		deltas, err := mtree.Check(dir, nil, mtreeKeywords, fseval.Default)
+		assert.NoError(t, err, "mtree check")
+
+		reader, err := GenerateLayer(dir, deltas, &packOptions)
+		assert.NoError(t, err, "generate layer")
+		defer reader.Close()
+
+		checkLayerEntries(t, reader, []tarDentry{
+			{path: ".", ftype: tar.TypeDir},
+			{path: "reg", ftype: tar.TypeReg, contents: "dummy file"},
+			{path: "wodir/", ftype: tar.TypeDir},
+			{path: "wodir/" + whOpaque, ftype: tar.TypeReg},
+		})
+	})
+
+	t.Run("GenerateInsertLayer", func(t *testing.T) {
+		reader := GenerateInsertLayer(dir, "/", false, &packOptions)
+		defer reader.Close()
+
+		checkLayerEntries(t, reader, []tarDentry{
+			{path: "/", ftype: tar.TypeDir},
+			{path: "reg", ftype: tar.TypeReg, contents: "dummy file"},
+			{path: "wodir/", ftype: tar.TypeDir},
+			{path: "wodir/" + whOpaque, ftype: tar.TypeReg},
+		})
+	})
+}
+
+func TestTranslateOverlayWhiteouts_XattrWhiteout(t *testing.T) {
+	dir := t.TempDir()
+
+	testNeedsTrustedOverlayXattrs(t)
+
+	err := os.WriteFile(filepath.Join(dir, "woreg"), []byte{}, 0755)
+	require.NoError(t, err)
+	err = unix.Lsetxattr(filepath.Join(dir, "woreg"), "trusted.overlay.whiteout", []byte("foobar"), 0)
+	require.NoError(t, err, "lsetxattr trusted.overlay.whiteout")
+	err = os.WriteFile(filepath.Join(dir, "reg"), []byte("dummy file"), 0644)
+	require.NoError(t, err)
+
+	packOptions := RepackOptions{TranslateOverlayWhiteouts: true}
+
+	t.Run("GenerateLayer", func(t *testing.T) {
+		// something reasonable
+		mtreeKeywords := []mtree.Keyword{
+			"size",
+			"type",
+			"uid",
+			"gid",
+			"mode",
+		}
+		deltas, err := mtree.Check(dir, nil, mtreeKeywords, fseval.Default)
+		assert.NoError(t, err, "mtree check")
+
+		reader, err := GenerateLayer(dir, deltas, &packOptions)
+		assert.NoError(t, err, "generate layer")
+		defer reader.Close()
+
+		checkLayerEntries(t, reader, []tarDentry{
+			{path: ".", ftype: tar.TypeDir},
+			{path: "reg", ftype: tar.TypeReg, contents: "dummy file"},
+			{path: whPrefix + "woreg", ftype: tar.TypeReg},
+		})
+	})
+
+	t.Run("GenerateInsertLayer", func(t *testing.T) {
+		reader := GenerateInsertLayer(dir, "/", false, &packOptions)
+		defer reader.Close()
+
+		checkLayerEntries(t, reader, []tarDentry{
+			{path: "/", ftype: tar.TypeDir},
+			{path: "reg", ftype: tar.TypeReg, contents: "dummy file"},
+			{path: whPrefix + "woreg", ftype: tar.TypeReg},
+		})
+	})
+}

--- a/oci/layer/generate_test.go
+++ b/oci/layer/generate_test.go
@@ -246,3 +246,20 @@ func TestGenerateWrongRootError(t *testing.T) {
 		}
 	}
 }
+
+func TestGenerateInsertWhiteout(t *testing.T) {
+	t.Run("WhiteoutPath", func(t *testing.T) {
+		reader := GenerateInsertLayer("", "foo/bar/baz", false, nil)
+		checkLayerEntries(t, reader, []tarDentry{
+			{path: "foo/bar/" + whPrefix + "baz", ftype: tar.TypeReg},
+		})
+	})
+
+	// opaque + whiteout should only result in a regular whiteout.
+	t.Run("BothWhiteouts", func(t *testing.T) {
+		reader := GenerateInsertLayer("", "foo/bar/baz", true, nil)
+		checkLayerEntries(t, reader, []tarDentry{
+			{path: "foo/bar/" + whPrefix + "baz", ftype: tar.TypeReg},
+		})
+	})
+}

--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -149,7 +149,10 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 	// Apply xattrs. In order to make sure that we *only* have the xattr set we
 	// want, we first clear the set of xattrs from the file then apply the ones
 	// set in the tar.Header.
-	err := te.fsEval.Lclearxattrs(path, ignoreXattrs)
+	err := te.fsEval.Lclearxattrs(path, func(xattr string) bool {
+		_, ok := ignoreXattrs[xattr]
+		return ok
+	})
 	if err != nil {
 		if !errors.Is(err, unix.ENOTSUP) {
 			return fmt.Errorf("clear xattr metadata: %s: %w", path, err)

--- a/oci/layer/tar_extract_linux_test.go
+++ b/oci/layer/tar_extract_linux_test.go
@@ -62,9 +62,9 @@ func TestUnpackEntry_OverlayFSWhiteout(t *testing.T) {
 
 	testNeedsMknod(t)
 
-	headers := []pseudoHdr{
-		{"file", "", tar.TypeReg},
-		{whPrefix + "file", "", tar.TypeReg},
+	dentries := []tarDentry{
+		{path: "file", ftype: tar.TypeReg},
+		{path: whPrefix + "file", ftype: tar.TypeReg},
 	}
 
 	unpackOptions := UnpackOptions{
@@ -76,8 +76,8 @@ func TestUnpackEntry_OverlayFSWhiteout(t *testing.T) {
 
 	te := NewTarExtractor(unpackOptions)
 
-	for _, ph := range headers {
-		hdr, rdr := fromPseudoHdr(ph)
+	for _, de := range dentries {
+		hdr, rdr := tarFromDentry(de)
 		err := te.UnpackEntry(dir, hdr, rdr)
 		assert.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
 	}
@@ -96,10 +96,10 @@ func TestUnpackEntry_OverlayFSOpaqueWhiteout(t *testing.T) {
 	testNeedsMknod(t)
 	testNeedsTrustedOverlayXattrs(t)
 
-	headers := []pseudoHdr{
-		{"dir", "", tar.TypeDir},
-		{"dir/fileindir", "dir", tar.TypeReg},
-		{"dir/" + whOpaque, "dir", tar.TypeReg},
+	dentries := []tarDentry{
+		{path: "dir", ftype: tar.TypeDir},
+		{path: "dir/fileindir", ftype: tar.TypeReg},
+		{path: "dir/" + whOpaque, ftype: tar.TypeReg},
 	}
 
 	unpackOptions := UnpackOptions{
@@ -111,8 +111,8 @@ func TestUnpackEntry_OverlayFSOpaqueWhiteout(t *testing.T) {
 
 	te := NewTarExtractor(unpackOptions)
 
-	for _, ph := range headers {
-		hdr, rdr := fromPseudoHdr(ph)
+	for _, de := range dentries {
+		hdr, rdr := tarFromDentry(de)
 		err := te.UnpackEntry(dir, hdr, rdr)
 		assert.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
 	}

--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -231,12 +231,13 @@ func (tg *tarGenerator) AddFile(name, path string) error {
 		//       (we'd need to use libcap to parse it).
 		value, err := tg.fsEval.Lgetxattr(path, name)
 		if err != nil {
-			// TODO: Should we use errors.As?
+			// Ignore xattrs we were unable to read or if the filesystem is
+			// refusing to provide information about them. Note that rather
+			// than getting a permission error when reading a trusted.* xattr
+			// as an unprivileged user, you actually get ENODATA.
 			log.Debugf("failure reading xattr from list on %q: %q", name, err)
+			// TODO: Should we use errors.As?
 			if !errors.Is(err, unix.EOPNOTSUPP) && !errors.Is(err, unix.ENODATA) {
-				// XXX: I'm not sure if we're unprivileged whether Lgetxattr can
-				//      fail with EPERM. If it can, we should ignore it (like when
-				//      we try to clear xattrs).
 				return fmt.Errorf("get xattr: %s: %w", name, err)
 			}
 		}

--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -32,49 +32,7 @@ import (
 
 	"github.com/opencontainers/umoci/pkg/fseval"
 	"github.com/opencontainers/umoci/pkg/system"
-	"github.com/opencontainers/umoci/pkg/testutils"
 )
-
-// ignoreXattrs is a list of xattr names that should be ignored when
-// creating a new image layer, because they are host-specific and/or would be a
-// bad idea to unpack. They are also excluded from Lclearxattr when extracting
-// an archive.
-// XXX: Maybe we should make this configurable so users can manually blacklist
-//
-//	(or even whitelist) xattrs that they actually want included? Like how
-//	GNU tar's xattr setup works.
-var ignoreXattrs = map[string]struct{}{
-	// SELinux doesn't allow you to set SELinux policies generically. They're
-	// also host-specific. So just ignore them during extraction.
-	"security.selinux": {},
-
-	// NFSv4 ACLs are very system-specific and shouldn't be touched by us, nor
-	// should they be included in images.
-	"system.nfs4_acl": {},
-
-	// In order to support overlayfs whiteout mode, we shouldn't un-set
-	// this after we've set it when writing out the whiteouts.
-	"trusted.overlay.opaque": {},
-
-	// We don't want to these xattrs into the image, because they're only
-	// relevant based on how the build overlay is constructed and will not
-	// be true on the target system once the image is unpacked (e.g. inodes
-	// might be different, impure status won't be true, etc.).
-	"trusted.overlay.redirect": {},
-	"trusted.overlay.origin":   {},
-	"trusted.overlay.impure":   {},
-	"trusted.overlay.nlink":    {},
-	"trusted.overlay.upper":    {},
-	"trusted.overlay.metacopy": {},
-}
-
-func init() {
-	// For test purposes we add a fake forbidden attribute that an unprivileged
-	// user can easily write to (and thus we can test it).
-	if testutils.IsTestBinary() {
-		ignoreXattrs["user.UMOCI:forbidden_xattr"] = struct{}{}
-	}
-}
 
 // tarGenerator is a helper for generating layer diff tars. It should be noted
 // that when using tarGenerator.Add{Path,Whiteout} it is recommended to do it
@@ -212,33 +170,42 @@ func (tg *tarGenerator) AddFile(name, path string) error {
 	// Set up xattrs externally to updateHeader because the function signature
 	// would look really dumb otherwise.
 	// XXX: This should probably be moved to a function in tar_unix.go.
-	names, err := tg.fsEval.Llistxattr(path)
+	xattrs, err := tg.fsEval.Llistxattr(path)
 	if err != nil {
 		if !errors.Is(err, unix.EOPNOTSUPP) {
 			return fmt.Errorf("get xattr list: %w", err)
 		}
-		names = []string{}
+		xattrs = []string{}
 	}
-	for _, name := range names {
+	for _, xattr := range xattrs {
 		// Some xattrs need to be skipped for sanity reasons, such as
 		// security.selinux, because they are very much host-specific and
-		// carrying them to other hosts would be a really bad idea.
-		if _, ignore := ignoreXattrs[name]; ignore {
-			continue
+		// carrying them to other hosts would be a really bad idea. Other
+		// xattrs need to be remapped (such as escaped trusted.overlay.* xattrs
+		// when in overlayfs mode) to have correct values.
+		mappedName := xattr
+		if filter, isSpecial := getXattrFilter(xattr); isSpecial {
+			if newName := filter.ToTar(tg.whiteoutMode, xattr); newName == nil {
+				log.Debugf("xattr{%s} skipping the inclusion of xattr %q in generated tar archive", hdr.Name, xattr)
+				continue
+			} else if *newName != xattr {
+				mappedName = *newName
+				log.Debugf("xattr{%s} remapping xattr %q to %q in generated tar archive", hdr.Name, xattr, mappedName)
+			}
 		}
 		// TODO: We should translate all v3 capabilities into root-owned
 		//       capabilities here. But we don't have Go code for that yet
 		//       (we'd need to use libcap to parse it).
-		value, err := tg.fsEval.Lgetxattr(path, name)
+		value, err := tg.fsEval.Lgetxattr(path, xattr)
 		if err != nil {
 			// Ignore xattrs we were unable to read or if the filesystem is
 			// refusing to provide information about them. Note that rather
 			// than getting a permission error when reading a trusted.* xattr
 			// as an unprivileged user, you actually get ENODATA.
-			log.Debugf("failure reading xattr from list on %q: %q", name, err)
+			log.Debugf("xattr{%s} failure reading xattr %q: %v", hdr.Name, xattr, err)
 			// TODO: Should we use errors.As?
 			if !errors.Is(err, unix.EOPNOTSUPP) && !errors.Is(err, unix.ENODATA) {
-				return fmt.Errorf("get xattr: %s: %w", name, err)
+				return fmt.Errorf("get xattr %q: %w", xattr, err)
 			}
 		}
 		// https://golang.org/issues/20698 -- We don't just error out here
@@ -246,12 +213,12 @@ func (tg *tarGenerator) AddFile(name, path string) error {
 		// whether the stdlib will correctly handle reading or disable writing
 		// of these PAX headers so we have to track this ourselves.
 		if len(value) <= 0 {
-			log.Warnf("ignoring empty-valued xattr %s: disallowed by PAX standard", name)
+			log.Warnf("xattr{%s} ignoring empty-valued xattr %q: disallowed by PAX standard", hdr.Name, xattr)
 			continue
 		}
 		// Note that Go strings can actually be arbitrary byte sequences, so
 		// this conversion (while it might look a bit wrong) is actually fine.
-		hdr.Xattrs[name] = string(value)
+		hdr.Xattrs[mappedName] = string(value)
 	}
 
 	// Not all systems have the concept of an inode, but I'm not in the mood to

--- a/oci/layer/tar_generate_test.go
+++ b/oci/layer/tar_generate_test.go
@@ -59,7 +59,7 @@ func TestTarGenerateAddFileNormal(t *testing.T) {
 	err = te.applyMetadata(path, expectedHdr)
 	require.NoError(t, err, "apply metadata")
 
-	tg := newTarGenerator(writer, MapOptions{})
+	tg := newTarGenerator(writer, RepackOptions{})
 	tr := tar.NewReader(reader)
 
 	// Create all of the tar entries in a goroutine so we can parse the tar
@@ -128,7 +128,7 @@ func TestTarGenerateAddFileDirectory(t *testing.T) {
 	err = te.applyMetadata(path, expectedHdr)
 	require.NoError(t, err, "apply metadata")
 
-	tg := newTarGenerator(writer, MapOptions{})
+	tg := newTarGenerator(writer, RepackOptions{})
 	tr := tar.NewReader(reader)
 
 	// Create all of the tar entries in a goroutine so we can parse the tar
@@ -198,7 +198,7 @@ func TestTarGenerateAddFileSymlink(t *testing.T) {
 	err = te.applyMetadata(path, expectedHdr)
 	require.NoError(t, err, "apply metadata")
 
-	tg := newTarGenerator(writer, MapOptions{})
+	tg := newTarGenerator(writer, RepackOptions{})
 	tr := tar.NewReader(reader)
 
 	// Create all of the tar entries in a goroutine so we can parse the tar
@@ -262,7 +262,7 @@ func TestTarGenerateAddWhiteout(t *testing.T) {
 		"dir/.",
 	}
 
-	tg := newTarGenerator(writer, MapOptions{})
+	tg := newTarGenerator(writer, RepackOptions{})
 	tr := tar.NewReader(reader)
 
 	// Create all of the whiteout entries in a goroutine so we can parse the

--- a/oci/layer/types.go
+++ b/oci/layer/types.go
@@ -46,11 +46,10 @@ type UnpackOptions struct {
 	// MapOptions are the UID and GID mappings used when unpacking an image
 	MapOptions MapOptions
 
-	// KeepDirlinks is essentially the same as rsync's optio
-	// --keep-dirlinks: if, on extraction, a directory would be created
-	// where a symlink to a directory previously existed, KeepDirlinks
-	// doesn't create that directory, but instead just uses the existing
-	// symlink.
+	// KeepDirlinks is essentially the same as rsync's --keep-dirlinks option.
+	// If, on extraction, a directory would be created where a symlink to a
+	// directory previously existed, KeepDirlinks doesn't create that
+	// directory, but instead just uses the existing symlink.
 	KeepDirlinks bool
 
 	// AfterLayerUnpack is a function that's called after every layer is

--- a/oci/layer/types.go
+++ b/oci/layer/types.go
@@ -22,6 +22,10 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+// TODO: Move away from separate WhiteoutMode and TranslateOverlayWhiteouts
+// configurations to a single "OnDiskFormat" configuration that will allow for
+// more complete overlayfs support.
+
 // WhiteoutMode indicates how this TarExtractor will create whiteouts on the
 // filesystem when it encounters them.
 type WhiteoutMode int

--- a/oci/layer/utils.go
+++ b/oci/layer/utils.go
@@ -23,12 +23,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/apex/log"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	rootlesscontainers "github.com/rootless-containers/proto/go-proto"
-	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/opencontainers/umoci/pkg/idtools"
@@ -211,23 +209,4 @@ func CleanPath(path string) string {
 
 	// Clean the path again for good measure.
 	return filepath.Clean(path)
-}
-
-// isOverlayWhiteout returns true if the FileInfo represents an overlayfs style
-// whiteout (i.e. mknod c 0 0) and false otherwise.
-func isOverlayWhiteout(info os.FileInfo) (bool, error) {
-	var major, minor uint32
-	switch stat := info.Sys().(type) {
-	case *unix.Stat_t:
-		major = unix.Major(uint64(stat.Rdev))
-		minor = unix.Minor(uint64(stat.Rdev))
-	case *syscall.Stat_t:
-		major = unix.Major(uint64(stat.Rdev))
-		minor = unix.Minor(uint64(stat.Rdev))
-	default:
-		return false, fmt.Errorf("[internal error] unknown stat info type %T", info.Sys())
-	}
-
-	return major == 0 && minor == 0 &&
-		info.Mode()&os.ModeCharDevice != 0, nil
 }

--- a/oci/layer/utils_unix.go
+++ b/oci/layer/utils_unix.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package layer
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/opencontainers/umoci/pkg/fseval"
+)
+
+type overlayWhiteoutType string
+
+const (
+	overlayWhiteoutPlain  overlayWhiteoutType = "plain whiteout"
+	overlayWhiteoutOpaque overlayWhiteoutType = "opaque whiteout"
+)
+
+// isOverlayWhiteout returns true if the given path is an overlayfs whiteout,
+// and what kind of whiteout it represents.
+func isOverlayWhiteout(path string, fsEval fseval.FsEval) (overlayWhiteoutType, bool, error) {
+	stat, err := fsEval.Lstatx(path)
+	if err != nil {
+		return "", false, err
+	}
+
+	switch stat.Mode & unix.S_IFMT {
+	case unix.S_IFCHR:
+		// classic char 0:0 style whiteouts
+		if stat.Rdev == 0 {
+			return overlayWhiteoutPlain, true, nil
+		}
+	case unix.S_IFDIR:
+		// opaque whiteouts
+		val, err := fsEval.Lgetxattr(path, "trusted.overlay.opaque")
+		if err != nil {
+			// If we are missing privileges to read the xattr (ENODATA) or the
+			// filesystem doesn't support xattrs (EOPNOTSUPP) we ignore the
+			// xattr.
+			if !errors.Is(err, unix.EOPNOTSUPP) && !errors.Is(err, unix.ENODATA) {
+				return "", false, fmt.Errorf("failed to get overlayfs opaque whiteout xattr: %w", err)
+			}
+			return "", false, nil
+		}
+		if bytes.Equal(val, []byte("y")) {
+			return overlayWhiteoutOpaque, true, nil
+		}
+		// TODO: What should we do for overlay.opaque=x? The docs imply that it
+		// should act like an opaque directory but in practice it seems that it
+		// only has an effect on whether overlay.whiteout shows up in readdir.
+	case unix.S_IFREG:
+		// overlayfs xattr-whiteouts
+		if stat.Size == 0 {
+			// Unlike overlay.opaque, the value stored in overlay.whiteout is
+			// not actually relevant -- it just needs to be set. Unprivileged
+			// users will get ENODATA if they try to read trusted.* xattrs
+			// (which is the same as for xattrs that don't exist), which would
+			// normally require us to ignore the xattr but we can very
+			// trivially work around this by listing the xattrs and checking if
+			// the xattr is present.
+			names, err := fsEval.Llistxattr(path)
+			if err != nil {
+				if !errors.Is(err, unix.EOPNOTSUPP) {
+					return "", false, fmt.Errorf("failed to get xattr list to look for overlayfs.whiteout: %w", err)
+				}
+				names = []string{}
+			}
+			if slices.Contains(names, "trusted.overlay.whiteout") {
+				return overlayWhiteoutPlain, true, nil
+			}
+		}
+	}
+	return "", false, nil
+}

--- a/oci/layer/xattr.go
+++ b/oci/layer/xattr.go
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package layer
+
+import (
+	"strings"
+
+	"github.com/apex/log"
+
+	"github.com/opencontainers/umoci/pkg/testutils"
+)
+
+// TODO: These method names are confusing since GenerateEntry() is called
+// during extraction to make restoreMetadata() not break things...
+
+// xattrFilter is used to modify xattrs during layer generation and extraction.
+// Very simple filters may completely block the layer generation and extraction
+// code from seeing certain system xattrs (such as security.selinux and
+// security.nfs4_acl), while others may require xattr names to be remapped
+// (such as with trusted.overlay.*).
+//
+// [ToTar] is conceptually the inverse of [ToDisk], though both can remove
+// xattrs entirely. Some key properties that [ToTar] implementations must
+// ensure are:
+//
+//   - For xattrs where ToTar(xattr) != nil, implementations must ensure that
+//     ToDisk(ToTar(xattr)) === xattr.
+//
+//   - For a given xattr and [WhiteoutMode], [MaskedOnDisk] must return true
+//     (meaning that the on-disk xattr will NOT be cleared) *if and only if*
+//     [ToTar] will returns nil.
+//
+// For xattrs that are not purely masked, you can think of [ToTar] as being
+// "unescape", and [ToDisk] being "escape", and [MaskedOnDisk] indicating
+// whether the xattr is something that [ToDisk] would *not* generate and
+// [ToTar] would
+// ignore.
+type xattrFilter interface {
+	// MaskedOnDisk indicates whether the given xattr should be hidden from
+	// code that iterates over on-disk xattrs (namely lclearxattrs). Note that
+	// we will (during the normal course of extraction) clear xattrs and
+	// re-apply them from tar archives, so xattrs should only be masked if
+	// umoci is simply not meant to interact with a given xattr.
+	//
+	// In particular, due to the implementation details of UnpackEntry
+	// (described in [ToTar]), MaskedOnDisk must only return true *if and only
+	// if* (for the same xattr and whiteout mode) [ToTar] would return nil and
+	// [ToDisk] would never generate it. Otherwise, it is impossible for this
+	// on-disk xattr to have come from or be stored in the archive.
+	MaskedOnDisk(onDiskMode WhiteoutMode, xattr string) bool
+
+	// ToDisk returns what name a tar archive xattr should be stored with
+	// on-disk (with the provided [WhiteoutMode] as the "on disk" format). The
+	// returned string will be used for as the on-disk xattr name instead of
+	// the original xattr -- if nil is returned then the xattr will not be
+	// extracted.
+	//
+	// [MaskedOnDisk] must only return true if [ToDisk] would never generate
+	// the same xattr.
+	ToDisk(onDiskMode WhiteoutMode, xattr string) (newName *string)
+
+	// ToTar returns what an on-disk xattr name should be converted to when
+	// storing in a tar archive (with the provided [WhiteoutMode] as the "on
+	// disk" format). The returned string will be stored inside tar archives as
+	// the xattr name instead of the original xattr -- if nil is returned then
+	// the xattr will not be included in the tar archive.
+	//
+	// Note that ToTar is not exclusively called on tar archive entries from
+	// layer archives. When doing UnpackEntry we need to restore the metadata
+	// of the parent directory of any path we extract into (to ensure that
+	// {a,c,m}times are correct), and an implementation detail of UnpackEntry
+	// is that this involves converting the on-disk information of the parent
+	// directory into a tar.Header and then back into the on-disk
+	// representation (to ensure that extracting entry metadata is identical to
+	// restoring parent directory metadata). This means that ToTar will be
+	// routinely called on directories that may have "special" xattrs.
+	//
+	// [MaskedOnDisk] must only return true for a given xattr and
+	// [WhiteoutMode] *if and only if*, ToTar with the same arguments returns
+	// nil. Otherwise, when the metadata is re-applied with on-disk data you
+	// will end up losing on-disk xattrs or adding new nonsense xattrs.
+	ToTar(onDiskMode WhiteoutMode, xattr string) (newName *string)
+}
+
+// forbiddenXattrFilter is a dummy filter that will block all xattrs that are
+// associated with it.
+type forbiddenXattrFilter struct{}
+
+var _ xattrFilter = forbiddenXattrFilter{}
+
+func (_ forbiddenXattrFilter) MaskedOnDisk(_ WhiteoutMode, _ string) bool { return true }
+func (_ forbiddenXattrFilter) ToDisk(_ WhiteoutMode, _ string) *string    { return nil }
+func (_ forbiddenXattrFilter) ToTar(_ WhiteoutMode, _ string) *string     { return nil }
+
+// overlayXattrFilter is a filter for all trusted.overlay.* xattrs which will
+// escape the xattrs on unpack and unescape them when
+type overlayXattrFilter struct{}
+
+var _ xattrFilter = overlayXattrFilter{}
+
+func (_ overlayXattrFilter) MaskedOnDisk(woMode WhiteoutMode, xattr string) bool {
+	// Only trusted.overlay.* top-level xattrs are masked in overlayfs mode.
+	// Escaped xattrs and xattrs in regular mode are allowed.
+	return woMode == OverlayFSWhiteout &&
+		doesXattrMatch(xattr, "trusted.overlay.") &&
+		!doesXattrMatch(xattr, "trusted.overlay.overlay.")
+}
+
+func (_ overlayXattrFilter) ToDisk(woMode WhiteoutMode, xattr string) *string {
+	if woMode != OverlayFSWhiteout {
+		// In non-overlayfs mode, overlay xattrs are not special and can be
+		// treated like any other xattr. (Though it would be a little strange
+		// to see them.)
+		return &xattr
+	}
+
+	subXattr, found := strings.CutPrefix(xattr, "trusted.overlay.")
+	if !found {
+		// We should never hit this case in practice.
+		// TODO: Should we just panic here?
+		log.Warnf("[internal error] overlayfs xattr filter called for non-overlayfs xattr %q", xattr)
+		return &xattr
+	}
+	escaped := "trusted.overlay.overlay." + subXattr
+	return &escaped
+}
+
+func (_ overlayXattrFilter) ToTar(woMode WhiteoutMode, xattr string) *string {
+	if woMode != OverlayFSWhiteout {
+		// In non-overlayfs mode, overlay xattrs are not special and can be
+		// treated like any other xattr. (Though it would be a little strange
+		// to see them.)
+		return &xattr
+	}
+
+	subXattr, isEscapedXattr := strings.CutPrefix(xattr, "trusted.overlay.overlay.")
+	if !isEscapedXattr {
+		// Clear any non-escaped xattrs entirely, as they may have been
+		// auto-set by overlayfs or set by the user when configuring overlayfs.
+		// This matches the behaviour of MaskedOnDisk.
+		return nil
+	}
+	unescaped := "trusted.overlay." + subXattr
+	return &unescaped
+}
+
+// specialXattrs is a list of xattr names (or prefixes) that may need have to
+// have special handling because treating them as-is would be incorrect (either
+// because they are host-specific and need to be hidden from images or would
+// result in counter-intuitive behaviour).
+//
+// TODO: Maybe we should make this configurable so users can manually blacklist
+// (or even whitelist) xattrs that they actually want included? Like how GNU
+// tar's xattr setup works.
+var specialXattrs = map[string]xattrFilter{
+	// SELinux doesn't allow you to set SELinux policies generically. They're
+	// also host-specific. So just ignore them during extraction.
+	"security.selinux": forbiddenXattrFilter{},
+
+	// NFSv4 ACLs are very system-specific and shouldn't be touched by us, nor
+	// should they be included in images.
+	"system.nfs4_acl": forbiddenXattrFilter{},
+
+	// The overlayfs namespace of xattrs need to have special handling when
+	// operating with the overlayfs on-disk format.
+	"trusted.overlay.": overlayXattrFilter{},
+}
+
+func init() {
+	// For test purposes we add a fake forbidden attribute that an unprivileged
+	// user can easily write to (and thus we can test it).
+	if testutils.IsTestBinary() {
+		specialXattrs["user.UMOCI:forbidden_xattr"] = forbiddenXattrFilter{}
+	}
+}
+
+// doesXattrMatch returns whether the given xattr matches the filter. The
+// semantics are very simple -- if the filter ends with "." then it is treated
+// as a prefix while if it doesn't end with "." it must match exactly.
+func doesXattrMatch(xattr, filter string) bool {
+	return filter == xattr ||
+		(strings.HasSuffix(filter, ".") && strings.HasPrefix(xattr, filter))
+}
+
+// getXattrFilter looks for the filter which matches xattr. isSpecial will be
+// true if there is a registered filter that matches the provided xattr.
+func getXattrFilter(xattr string) (filter xattrFilter, isSpecial bool) {
+	// fast path: look up the xattr directly
+	if filter, ok := specialXattrs[xattr]; ok {
+		return filter, ok
+	}
+	// slow path: match xattr prefixes
+	for prefix, filter := range specialXattrs {
+		if doesXattrMatch(xattr, prefix) {
+			return filter, true
+		}
+	}
+	return nil, false
+}

--- a/oci/layer/xattr_test.go
+++ b/oci/layer/xattr_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ * Copyright (C) 2020 Cisco Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package layer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoesXattrMatch(t *testing.T) {
+	for _, test := range []struct {
+		filter, xattr string
+		expected      bool
+	}{
+		// exact match mode
+		{"foo.bar", "foo.bar", true},
+		{"foo.bar", "foo.bara", false},
+		{"foo.bar", "foo.bar.a", false},
+		{"foo.bar", "foo.bar.a.b.c", false},
+		// prefix mode
+		{"foo.bar.", "foo.bar", false},
+		{"foo.bar.", "foo.bara", false},
+		{"foo.bar.", "foo.bar.a", true},
+		{"foo.bar.", "foo.bar.a.b.c", true},
+	} {
+		got := doesXattrMatch(test.xattr, test.filter)
+		assert.Equalf(t, test.expected, got, "doesXattrMatch(%q, %q)", test.xattr, test.filter)
+	}
+}
+
+func TestGetXattrFilter(t *testing.T) {
+	for _, test := range []struct {
+		xattr          string
+		expectedFilter xattrFilter
+		expectedOk     bool
+	}{
+		// exact matches
+		{"security.selinux", forbiddenXattrFilter{}, true},
+		{"security.selinux.foo", nil, false},
+		{"security.sel", nil, false},
+		{"security.capability", nil, false},
+		{"system.nfs4_acl", forbiddenXattrFilter{}, true},
+		{"system.nfs4_foo", nil, false},
+		{"system.foo", nil, false},
+		// prefixes
+		{"trusted.overlay.opaque", overlayXattrFilter{}, true},
+		{"trusted.overlay.whiteout", overlayXattrFilter{}, true},
+		{"trusted.overlay.foobar", overlayXattrFilter{}, true},
+		{"trusted.overlay.a.b.c", overlayXattrFilter{}, true},
+		{"trusted.overlay", nil, false},
+		// unrelated
+		{"user.foo.bar", nil, false},
+		{"user.overlay.opaque", nil, false},
+		{"user.trusted.overlay.opaque", nil, false},
+		{"user.rootlesscontainers", nil, false},
+	} {
+		filter, ok := getXattrFilter(test.xattr)
+		assert.Equalf(t, test.expectedOk, ok, "getXattrFilter(%q)", test.xattr)
+		assert.Equalf(t, test.expectedFilter, filter, "getXattrFilter(%q)", test.xattr)
+	}
+}

--- a/pkg/fseval/fseval.go
+++ b/pkg/fseval/fseval.go
@@ -77,7 +77,7 @@ type FsEval interface {
 	Lgetxattr(path string, name string) ([]byte, error)
 
 	// Lclearxattrs is equivalent to system.Lclearxattrs
-	Lclearxattrs(path string, except map[string]struct{}) error
+	Lclearxattrs(path string, skipFn func(xattr string) bool) error
 
 	// Walk is equivalent to filepath.Walk.
 	Walk(root string, fn filepath.WalkFunc) error

--- a/pkg/fseval/fseval_default.go
+++ b/pkg/fseval/fseval_default.go
@@ -136,8 +136,8 @@ func (fs osFsEval) Lgetxattr(path string, name string) ([]byte, error) {
 }
 
 // Lclearxattrs is equivalent to system.Lclearxattrs
-func (fs osFsEval) Lclearxattrs(path string, except map[string]struct{}) error {
-	return system.Lclearxattrs(path, except)
+func (fs osFsEval) Lclearxattrs(path string, skipFn func(xattrName string) bool) error {
+	return system.Lclearxattrs(path, skipFn)
 }
 
 // KeywordFunc returns a wrapper around the given mtree.KeywordFunc.

--- a/pkg/fseval/fseval_rootless.go
+++ b/pkg/fseval/fseval_rootless.go
@@ -125,8 +125,8 @@ func (fs unprivFsEval) Lgetxattr(path string, name string) ([]byte, error) {
 }
 
 // Lclearxattrs is equivalent to unpriv.Lclearxattrs
-func (fs unprivFsEval) Lclearxattrs(path string, except map[string]struct{}) error {
-	return unpriv.Lclearxattrs(path, except)
+func (fs unprivFsEval) Lclearxattrs(path string, skipFn func(xattrName string) bool) error {
+	return unpriv.Lclearxattrs(path, skipFn)
 }
 
 // KeywordFunc returns a wrapper around the given mtree.KeywordFunc.

--- a/pkg/pathtrie/trie.go
+++ b/pkg/pathtrie/trie.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pathtrie
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+type trieNode[V any] struct {
+	value    *V
+	children map[string]*trieNode[V]
+}
+
+func newNode[V any]() *trieNode[V] {
+	return &trieNode[V]{
+		value:    nil,
+		children: map[string]*trieNode[V]{},
+	}
+}
+
+type pathKey string
+
+func pathToKey(path string) pathKey {
+	path = filepath.Clean(string(filepath.Separator) + path)
+	if filepath.IsAbs(path) {
+		path = strings.TrimPrefix(path, string(filepath.Separator))
+	}
+	path = filepath.ToSlash(path)
+	return pathKey(path)
+}
+
+// lookupNode looks up the node at the given path. If alloc is set then any
+// missing nodes are created. path MUST be filepath.ToSlash and
+// filepath.Clean'd.
+func (root *trieNode[V]) lookupNode(path pathKey, alloc bool) *trieNode[V] {
+	if path == "" {
+		return root
+	}
+	top, remaining, _ := strings.Cut(string(path), "/")
+
+	next, exists := root.children[top]
+	if !exists && alloc {
+		root.children[top] = newNode[V]()
+		next, exists = root.children[top]
+	}
+	if !exists {
+		return nil
+	}
+	return next.lookupNode(pathKey(remaining), alloc)
+}
+
+type PathTrie[V any] struct {
+	*trieNode[V]
+}
+
+// NewTrie returns a new empty [PathTrie].
+func NewTrie[V any]() *PathTrie[V] {
+	return &PathTrie[V]{newNode[V]()}
+}
+
+// Get looks up the given path in the trie. Completely non-existent paths and
+// paths with no value (such as intermediate paths) are considered the same.
+func (t *PathTrie[V]) Get(path string) (val V, found bool) {
+	key := pathToKey(path)
+	node := t.lookupNode(key, false)
+	if node != nil && node.value != nil {
+		return *node.value, true
+	}
+	return val, false
+}
+
+// Set adds a new value to the trie at the given path with the given value. If
+// there was a value at the given path, the old value is returned and found
+// will be true.
+func (t *PathTrie[V]) Set(path string, value V) (old V, found bool) {
+	key := pathToKey(path)
+	node := t.lookupNode(key, true)
+	if node.value != nil {
+		old = *node.value
+		found = true
+	}
+	node.value = &value
+	return old, found
+}
+
+func (t *PathTrie[V]) delete(path string, recursive bool) (old V, found bool) {
+	// Need to look up the parent node of the path.
+	dir, file := filepath.Split(filepath.Clean(path))
+	dirKey := pathToKey(dir)
+	node := t.lookupNode(dirKey, false)
+	if node == nil {
+		return old, false
+	}
+	if child, ok := node.children[file]; ok {
+		// Delete the value from the node if it existed.
+		if child.value != nil {
+			old, found = *child.value, true
+		}
+		child.value = nil
+		// If the node has no children (or we are doing recursive removals),
+		// remove it as well to avoid keeping around garbage.
+		//
+		// TODO: In the case of us deleting an intermediate node that had a
+		// child several layers deeper that has been removed, we will not
+		// delete the now-unneeded nodes. The most obvious optimisation is to
+		// store a count of the number of children per-layer which we update up
+		// the tree recursively so we can detect if it's safe to prune the
+		// children -- the only downside is it will complicated our simple
+		// lookupNode code.
+		if recursive || len(child.children) == 0 {
+			delete(node.children, file)
+		}
+	}
+	return old, found
+}
+
+// Delete removes the value at the given path, but any child entries are kept
+// as-is. To remove the entry and all child entries use [DeleteAll]. If there
+// was a value at the given path, the old value is returned and found will be
+// true.
+func (t *PathTrie[V]) Delete(path string) (old V, found bool) {
+	return t.delete(path, false)
+}
+
+// DeleteAll removes the entry at the given path and all child entries. To only
+// delete the value at the path use [Delete]. If there was a value at the given
+// path, the old value is returned and found will be true.
+func (t *PathTrie[V]) DeleteAll(path string) (old V, found bool) {
+	return t.delete(path, true)
+}
+
+// WalkFunc is the callback function called by [WalkFrom].
+type WalkFunc[V any] func(path string, value V) error
+
+func walk[V any](current *trieNode[V], path string, walkFn WalkFunc[V]) error {
+	if current.value != nil {
+		if err := walkFn(path, *current.value); err != nil {
+			return err
+		}
+	}
+	for file, child := range current.children {
+		childPath := filepath.Join(path, file)
+		if err := walk(child, childPath, walkFn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WalkFrom does a depth-first walk of the trie starting at the given path. The
+// exact order of execution is not guaranteed to be the same each time (as node
+// children are stored as maps).
+func (t *PathTrie[V]) WalkFrom(path string, walkFn WalkFunc[V]) error {
+	key := pathToKey(path)
+	node := t.lookupNode(key, false)
+	if node != nil {
+		return walk(node, filepath.Clean(path), walkFn)
+	}
+	return nil
+}

--- a/pkg/pathtrie/trie_test.go
+++ b/pkg/pathtrie/trie_test.go
@@ -1,0 +1,470 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pathtrie
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testSetNew[V any](t *testing.T, trie *PathTrie[V], path string, value V) {
+	old, found := trie.Set(path, value)
+	assert.Falsef(t, found, "Set(%q) of non-existent path should not return an old value", path)
+	assert.Emptyf(t, old, "Set(%q) of non-existent path should not return an old value", path)
+}
+
+func testSetReplace[V any](t *testing.T, trie *PathTrie[V], path string, value, expectedOld V) {
+	old, found := trie.Set(path, value)
+	assert.Truef(t, found, "Set(%q) of existing path should return an old value", path)
+	assert.Equalf(t, expectedOld, old, "Set(%q) of existing path should return an old value", path)
+}
+
+func testGetFail[V any](t *testing.T, trie *PathTrie[V], path string) {
+	got, found := trie.Get(path)
+	assert.Falsef(t, found, "Get(%q) of non-existent path should not return a value", path)
+	assert.Emptyf(t, got, "Get(%q) of non-existent path should not return a value", path)
+}
+
+func testGetSucceed[V any](t *testing.T, trie *PathTrie[V], path string, expectedValue V) {
+	got, found := trie.Get(path)
+	assert.Truef(t, found, "Get(%q) of existing path should return correct value", path)
+	assert.Equalf(t, expectedValue, got, "Get(%q) of existing path should return correct value", path)
+}
+
+func testDeleteNonExist[V any](t *testing.T, trie *PathTrie[V], path string) {
+	got, found := trie.Delete(path)
+	assert.Falsef(t, found, "Delete(%q) of non-existent path should not return an old value", path)
+	assert.Emptyf(t, got, "Delete(%q) of non-existent path should not return an old value", path)
+}
+
+func testDeleteInternal[V any](t *testing.T, trie *PathTrie[V], path string) {
+	got, found := trie.Delete(path)
+	assert.Falsef(t, found, "Delete(%q) of internal non-value path should not return an old value", path)
+	assert.Emptyf(t, got, "Delete(%q) of internal non-value path should not return an old value", path)
+}
+
+func testDeleteExist[V any](t *testing.T, trie *PathTrie[V], path string, expectedValue V) {
+	got, found := trie.Delete(path)
+	assert.Truef(t, found, "Delete(%q) of existing path should return correct value", path)
+	assert.Equalf(t, expectedValue, got, "Delete(%q) of existing path should return correct value", path)
+}
+
+func testDeleteAllNonExist[V any](t *testing.T, trie *PathTrie[V], path string) {
+	got, found := trie.DeleteAll(path)
+	assert.Falsef(t, found, "DeleteAll(%q) of non-existent path should not return an old value", path)
+	assert.Emptyf(t, got, "DeleteAll(%q) of non-existent path should not return an old value", path)
+}
+
+func testDeleteAllInternal[V any](t *testing.T, trie *PathTrie[V], path string) {
+	got, found := trie.DeleteAll(path)
+	assert.Falsef(t, found, "DeleteAll(%q) of internal non-value path should not return an old value", path)
+	assert.Emptyf(t, got, "DeleteAll(%q) of internal non-value path should not return an old value", path)
+}
+
+func testDeleteAllExist[V any](t *testing.T, trie *PathTrie[V], path string, expectedValue V) {
+	got, found := trie.DeleteAll(path)
+	assert.Truef(t, found, "DeleteAll(%q) of existing path should return correct value", path)
+	assert.Equalf(t, expectedValue, got, "DeleteAll(%q) of existing path should return correct value", path)
+}
+
+func TestGetNonExistent(t *testing.T) {
+	trie := NewTrie[string]()
+
+	testGetFail(t, trie, "/a/b/c/d")
+	testSetNew(t, trie, "/a/b/c/d", "abcd")
+	testGetFail(t, trie, "/a/b/c")
+	testGetFail(t, trie, "/a/b/c/dd")
+}
+
+func TestSetGetBasic(t *testing.T) {
+	trie := NewTrie[string]()
+
+	testSetNew(t, trie, "/a/b/c/d", "abcd")
+	testGetSucceed(t, trie, "/a/b/c/d", "abcd")
+	// Make sure that leading slashes and other stuff cleaned by filepath.Clean
+	// don't impact the results.
+	testGetSucceed(t, trie, "a/b/c/d", "abcd")
+	testGetSucceed(t, trie, "/../a/b/c/d", "abcd")
+	testGetSucceed(t, trie, "a///b/./c/./d/", "abcd")
+}
+
+func TestSetMultiple(t *testing.T) {
+	trie := NewTrie[string]()
+
+	testSetNew(t, trie, "/a/b/c/d", "abcd")
+	testSetReplace(t, trie, "/a/b/c/d", "ABCD", "abcd")
+	testSetReplace(t, trie, "/a/b/c/d", "aBcD", "ABCD")
+	testGetSucceed(t, trie, "/a/b/c/d", "aBcD")
+}
+
+func TestDelete(t *testing.T) {
+	trie := NewTrie[string]()
+
+	testSetNew(t, trie, "/a/b/c/d", "abcd")
+	testSetNew(t, trie, "/a/b", "ab")
+	testSetNew(t, trie, "/a", "a")
+	testSetNew(t, trie, "/b/c", "bc")
+
+	testGetSucceed(t, trie, "/a/b/c/d", "abcd")
+	testGetSucceed(t, trie, "/a/b", "ab")
+	testGetSucceed(t, trie, "/a", "a")
+	testGetSucceed(t, trie, "/b/c", "bc")
+
+	t.Run("NonExistent", func(t *testing.T) {
+		testDeleteNonExist(t, trie, "/non/exist")
+
+		// Verify that the nodes weren't created.
+		node1 := trie.lookupNode(pathToKey("/non"), false)
+		assert.Nil(t, node1, "node /non should not have been created")
+		node2 := trie.lookupNode(pathToKey("/non/exist"), false)
+		assert.Nil(t, node2, "node /non/exist should not have been created")
+	})
+
+	t.Run("NoValue", func(t *testing.T) {
+		testDeleteInternal(t, trie, "/a/b/c")
+
+		testGetSucceed(t, trie, "/a/b/c/d", "abcd")
+		testGetSucceed(t, trie, "/a/b", "ab")
+		testGetSucceed(t, trie, "/a", "a")
+		testGetSucceed(t, trie, "/b/c", "bc")
+	})
+
+	t.Run("Parent", func(t *testing.T) {
+		testDeleteExist(t, trie, "/a/b", "ab")
+
+		testGetSucceed(t, trie, "/a/b/c/d", "abcd")
+		testGetFail(t, trie, "/a/b")
+		testGetSucceed(t, trie, "/a", "a")
+		testGetSucceed(t, trie, "/b/c", "bc")
+	})
+
+	t.Run("Final", func(t *testing.T) {
+		testDeleteExist(t, trie, "/a/b/c/d", "abcd")
+
+		testGetFail(t, trie, "/a/b/c/d")
+		testGetFail(t, trie, "/a/b")
+		testGetSucceed(t, trie, "/a", "a")
+		testGetSucceed(t, trie, "/b/c", "bc")
+
+		// Verify that the final node is actually gone.
+		node1 := trie.lookupNode(pathToKey("/a/b/c/d"), false)
+		assert.Nilf(t, node1, "node /a/b/c/d should've been pruned -- got %#v", node1)
+	})
+
+	// TODO: If we switch to making Delete clear trash more aggressively, we
+	// should test that here.
+}
+
+func TestDeleteAll(t *testing.T) {
+	trie := NewTrie[string]()
+
+	testSetNew(t, trie, "/a/b/c/d", "abcd")
+	testSetNew(t, trie, "/a/b/c/d/e/f", "abcdef")
+	testSetNew(t, trie, "/a/b/c/d/e", "abcde")
+	testSetNew(t, trie, "/a/b", "ab")
+	testSetNew(t, trie, "/a/foo", "afoo")
+	testSetNew(t, trie, "/b/c", "bc")
+
+	testGetSucceed(t, trie, "/a/b/c/d/e/f", "abcdef")
+	testGetSucceed(t, trie, "/a/b/c/d/e", "abcde")
+	testGetSucceed(t, trie, "/a/b/c/d", "abcd")
+	testGetSucceed(t, trie, "/a/b", "ab")
+	testGetSucceed(t, trie, "/a/foo", "afoo")
+	testGetSucceed(t, trie, "/b/c", "bc")
+
+	t.Run("NonExistent", func(t *testing.T) {
+		testDeleteAllNonExist(t, trie, "/non/exist")
+
+		// Verify that the nodes weren't created.
+		node1 := trie.lookupNode(pathToKey("/non"), false)
+		assert.Nilf(t, node1, "node /non should not have been created -- got %#v", node1)
+		node2 := trie.lookupNode(pathToKey("/non/exist"), false)
+		assert.Nilf(t, node2, "node /non/exist should not have been created -- got %#v", node2)
+	})
+
+	t.Run("Final", func(t *testing.T) {
+		testDeleteAllExist(t, trie, "/a/b/c/d/e/f", "abcdef")
+
+		testGetFail(t, trie, "/a/b/c/d/e/f")
+		testGetSucceed(t, trie, "/a/b/c/d/e", "abcde")
+		testGetSucceed(t, trie, "/a/b/c/d", "abcd")
+		testGetSucceed(t, trie, "/a/b", "ab")
+		testGetSucceed(t, trie, "/a/foo", "afoo")
+		testGetSucceed(t, trie, "/b/c", "bc")
+
+		// Verify that the final node is actually gone.
+		node := trie.lookupNode(pathToKey("/a/b/c/d/e/f"), false)
+		assert.Nilf(t, node, "node /a/b/c/d/e/f should've been pruned -- got %#v", node)
+	})
+
+	t.Run("Parent", func(t *testing.T) {
+		testDeleteAllExist(t, trie, "/a/b/c/d", "abcd")
+
+		testGetFail(t, trie, "/a/b/c/d/e/f")
+		testGetFail(t, trie, "/a/b/c/d/e")
+		testGetFail(t, trie, "/a/b/c/d")
+		testGetSucceed(t, trie, "/a/b", "ab")
+		testGetSucceed(t, trie, "/a/foo", "afoo")
+		testGetSucceed(t, trie, "/b/c", "bc")
+
+		// Verify that the intermediate nodes are actually gone.
+		node1 := trie.lookupNode(pathToKey("/a/b/c/d/e"), false)
+		assert.Nilf(t, node1, "node /a/b/c/d/e should've been pruned -- got %#v", node1)
+		node2 := trie.lookupNode(pathToKey("/a/b/c/d"), false)
+		assert.Nilf(t, node2, "node /a/b/c/d should've been pruned -- got %#v", node2)
+	})
+
+	t.Run("NoValue", func(t *testing.T) {
+		testDeleteAllInternal(t, trie, "/a")
+
+		testGetFail(t, trie, "/a/b/c/d/e/f")
+		testGetFail(t, trie, "/a/b/c/d/e")
+		testGetFail(t, trie, "/a/b/c/d")
+		testGetFail(t, trie, "/a/b/c")
+		testGetFail(t, trie, "/a/b")
+		testGetFail(t, trie, "/a/foo")
+		testGetFail(t, trie, "/a")
+		testGetSucceed(t, trie, "/b/c", "bc")
+
+		// Verify that the intermediate nodes are actually gone.
+		node1 := trie.lookupNode(pathToKey("/a/b/c"), false)
+		assert.Nilf(t, node1, "node /a/b/c should've been pruned -- got %#v", node1)
+		node2 := trie.lookupNode(pathToKey("/a/b"), false)
+		assert.Nilf(t, node2, "node /a/b should've been pruned -- got %#v", node2)
+		node3 := trie.lookupNode(pathToKey("/a/foo"), false)
+		assert.Nilf(t, node3, "node /a/foo should've been pruned -- got %#v", node3)
+		node4 := trie.lookupNode(pathToKey("/a"), false)
+		assert.Nilf(t, node4, "node /a should've been pruned -- got %#v", node4)
+	})
+
+	testGetSucceed(t, trie, "/b/c", "bc")
+}
+
+func TestWalk(t *testing.T) {
+	trie := NewTrie[string]()
+
+	testSetNew(t, trie, "/a/b/c/d", "abcd")
+	testSetNew(t, trie, "/a/b/c/d/e/f", "abcdef")
+	testSetNew(t, trie, "/a/b/c/d/e/ff", "abcdeff")
+	testSetNew(t, trie, "/a/b/c/d/e", "abcde")
+	testSetNew(t, trie, "/a/b/cc", "abcc")
+	testSetNew(t, trie, "/a/b/cc/dd/ee/ff", "abccddeeff")
+	testSetNew(t, trie, "/a/b", "ab")
+	testSetNew(t, trie, "/a/foo", "afoo")
+	testSetNew(t, trie, "/a/foo/bar/baz", "afoobarbaz")
+	testSetNew(t, trie, "/a/boop", "aboop")
+	testSetNew(t, trie, "/b/c", "bc")
+	testSetNew(t, trie, "/e/f", "ef")
+	testSetNew(t, trie, "/baz", "baz")
+
+	type foundEntry struct {
+		path, value string
+	}
+
+	t.Run("EmptyRoot", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("/", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{"/a/b/c/d", "abcd"},
+			{"/a/b/c/d/e/f", "abcdef"},
+			{"/a/b/c/d/e/ff", "abcdeff"},
+			{"/a/b/c/d/e", "abcde"},
+			{"/a/b/cc", "abcc"},
+			{"/a/b/cc/dd/ee/ff", "abccddeeff"},
+			{"/a/b", "ab"},
+			{"/a/foo", "afoo"},
+			{"/a/foo/bar/baz", "afoobarbaz"},
+			{"/a/boop", "aboop"},
+			{"/b/c", "bc"},
+			{"/e/f", "ef"},
+			{"/baz", "baz"},
+		})
+	})
+
+	t.Run("DeepSubPath", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("/a/b", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{"/a/b/c/d", "abcd"},
+			{"/a/b/c/d/e/f", "abcdef"},
+			{"/a/b/c/d/e/ff", "abcdeff"},
+			{"/a/b/c/d/e", "abcde"},
+			{"/a/b/cc", "abcc"},
+			{"/a/b/cc/dd/ee/ff", "abccddeeff"},
+			{"/a/b", "ab"},
+		})
+	})
+
+	t.Run("ShallowSubPath", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("/b", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{"/b/c", "bc"},
+		})
+	})
+
+	t.Run("SingleEntry", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("/a/b/c/d/e/ff", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{"/a/b/c/d/e/ff", "abcdeff"},
+		})
+	})
+
+	t.Run("NonExistent", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("/non/exist", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.Empty(t, sawEntries, "walk trie in non-existent path should not see anything")
+	})
+
+	testSetNew(t, trie, "/", "i am root")
+
+	t.Run("Root-Abs", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("/", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{"/", "i am root"},
+			{"/a/b/c/d", "abcd"},
+			{"/a/b/c/d/e/f", "abcdef"},
+			{"/a/b/c/d/e/ff", "abcdeff"},
+			{"/a/b/c/d/e", "abcde"},
+			{"/a/b/cc", "abcc"},
+			{"/a/b/cc/dd/ee/ff", "abccddeeff"},
+			{"/a/b", "ab"},
+			{"/a/foo", "afoo"},
+			{"/a/foo/bar/baz", "afoobarbaz"},
+			{"/a/boop", "aboop"},
+			{"/b/c", "bc"},
+			{"/e/f", "ef"},
+			{"/baz", "baz"},
+		})
+	})
+
+	t.Run("Root-Dot", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom(".", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{".", "i am root"},
+			{"a/b/c/d", "abcd"},
+			{"a/b/c/d/e/f", "abcdef"},
+			{"a/b/c/d/e/ff", "abcdeff"},
+			{"a/b/c/d/e", "abcde"},
+			{"a/b/cc", "abcc"},
+			{"a/b/cc/dd/ee/ff", "abccddeeff"},
+			{"a/b", "ab"},
+			{"a/foo", "afoo"},
+			{"a/foo/bar/baz", "afoobarbaz"},
+			{"a/boop", "aboop"},
+			{"b/c", "bc"},
+			{"e/f", "ef"},
+			{"baz", "baz"},
+		})
+	})
+
+	t.Run("Root-EmptyString", func(t *testing.T) {
+		var sawEntries []foundEntry
+		err := trie.WalkFrom("", func(path, value string) error {
+			sawEntries = append(sawEntries, foundEntry{
+				path:  path,
+				value: value,
+			})
+			return nil
+		})
+		require.NoError(t, err, "walk trie")
+		assert.ElementsMatch(t, sawEntries, []foundEntry{
+			{".", "i am root"},
+			{"a/b/c/d", "abcd"},
+			{"a/b/c/d/e/f", "abcdef"},
+			{"a/b/c/d/e/ff", "abcdeff"},
+			{"a/b/c/d/e", "abcde"},
+			{"a/b/cc", "abcc"},
+			{"a/b/cc/dd/ee/ff", "abccddeeff"},
+			{"a/b", "ab"},
+			{"a/foo", "afoo"},
+			{"a/foo/bar/baz", "afoobarbaz"},
+			{"a/boop", "aboop"},
+			{"b/c", "bc"},
+			{"e/f", "ef"},
+			{"baz", "baz"},
+		})
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		testErr := fmt.Errorf("test error")
+		err := trie.WalkFrom("/", func(path, value string) error {
+			if path == "/a/b/cc" {
+				return testErr
+			}
+			return nil
+		})
+		require.ErrorIs(t, err, testErr, "walk trie")
+	})
+}

--- a/pkg/system/xattr_unix_test.go
+++ b/pkg/system/xattr_unix_test.go
@@ -73,7 +73,10 @@ func TestClearxattrFilter(t *testing.T) {
 	assert.ElementsMatch(t, setXattrNames, allXattrList, "all xattrs should be present after setting")
 
 	// Now clear them.
-	err = Lclearxattrs(path, forbiddenXattrs)
+	err = Lclearxattrs(path, func(xattrName string) bool {
+		_, ok := forbiddenXattrs[xattrName]
+		return ok
+	})
 	require.NoErrorf(t, err, "lclearxattrs %q (forbidden=%v)", path, forbiddenXattrs)
 
 	// Check that only the forbidden ones remain.

--- a/pkg/unpriv/unpriv.go
+++ b/pkg/unpriv/unpriv.go
@@ -566,8 +566,8 @@ func Lgetxattr(path, name string) ([]byte, error) {
 // Lclearxattrs is a wrapper around system.Lclearxattrs which has been wrapped
 // with unpriv.Wrap to make it possible to get a path even if you do not
 // currently have the required access bits to resolve the path.
-func Lclearxattrs(path string, except map[string]struct{}) error {
-	err := Wrap(path, func(path string) error { return system.Lclearxattrs(path, except) })
+func Lclearxattrs(path string, skipFn func(xattrName string) bool) error {
+	err := Wrap(path, func(path string) error { return system.Lclearxattrs(path, skipFn) })
 	if err != nil {
 		return fmt.Errorf("unpriv.lclearxattrs: %w", err)
 	}

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -146,8 +146,8 @@ function umoci() {
 	#       the subcommand. We should probably switch to getopt here.
 	args+=("$1")
 
-	# We're rootless if we're asked to unpack something.
-	if [[ "$IS_ROOTLESS" != 0 && "$1" == "unpack" ]]; then
+	# Set --rootless for commands that require it when we're rootless.
+	if [[ "$IS_ROOTLESS" != 0 && "$1" =~ unpack|insert ]]; then
 		args+=("--rootless")
 	fi
 


### PR DESCRIPTION
It turns out that a lot of our overlayfs whiteout conversion code is actually quite broken, and quite a few things are not properly supported. Here are the set of issues we needed to fix:

- [x] `GenerateLayer` would produce whiteouts with the wrong pathname (it would use the full path rather than the layer path), leaking information about the host and producing incorrect images as output.
- [x] `GenerateLayer` would skip any non-whiteouts files when operating in `TranslateOverlayfsWhiteout` mode, silently losing data.
- [x] Our testing of `TranslateOverlayfsWhiteout` was quite crude.
- [x] The `GenerateInsertLayer` code would not use `fsEval` in most places, which would cause rootless mode to not work properly.
- [x] We need to support converting `trusted.overlay.opaque=y` since users might use that to specify opaque whiteouts (there is no other way to specify this when umoci generates archives).
  - This is a reimplementation of #538 (which had several issues).
- [x] Extracting overlayfs whiteouts doesn't work if there are missing parent directories or the filetype of the opaque dir is wrong. In practice this is not an issue with most images but for completeness we should handle this case properly.
- [x] Currently extracting regular whiteouts in an opaque whiteout directory will lead to confusing effects with `overlayfs` (`readdir` will report the existence of files that are whited out).
  - We will probably need to switch `(*tarExtractor).upperPaths` to be a trie that will allow us to remove already-extracted regular whiteouts from a directory that then gets tagged as an opaque whiteout, as well as skip extracting regular whiteouts from a directory that is already and opaque whiteout. None of this is necessary for regular extractions but overlayfs kind of forces us to do this.
- :twisted_rightwards_arrows: `user.overlay.*` support feature moved to #576.
- [x] We need to support the `trusted.overlay.` escaping so that:
  - Repacking a regular non-overlayfs layer with `trusted.overlay.*` will keep the same xattr name.
  - Repacking an overlayfs layer with `trusted.overlay.*` will strip the xattrs but `trusted.overlay.overlay.*` will have one layer of escaping stripped when generating the tar archive.
  - Ditto when unpacking -- for non-overlayfs we extract as normal but for overlayfs we need to add escaping.