### PR TITLE
oci: layer: refix auto-applied xattr handling

### DIFF
--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -581,7 +581,7 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 						// being cleared. However, just to be safe we should
 						// verify that this is actually true (otherwise you'll
 						// end up with silently wrong extractions).
-						if filter.MaskedOnDisk(te.whiteoutMode, xattr) {
+						if !filter.MaskedOnDisk(te.whiteoutMode, xattr) {
 							// TODO: Find a nicer setup that doesn't require
 							// this fatal error.
 							log.Fatalf("[internal error] xattr{%s} masked %q is being hidden by (%T).GenerateEntry but UnpackShouldClear returns true", unsafeDir, xattr, filter)

--- a/oci/layer/xattr_linux_test.go
+++ b/oci/layer/xattr_linux_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vbatts/go-mtree"
+	"golang.org/x/sys/unix"
 
 	"github.com/opencontainers/umoci/pkg/fseval"
 	"github.com/opencontainers/umoci/pkg/system"
@@ -207,6 +208,123 @@ func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
 					assert.Equalf(t, de.xattrs, xattrs, "UnpackEntry(%q): expected to see %#v not be remapped", path, de.xattrs)
 					assert.NotEqualf(t, de.remapXattrs, xattrs, "UnpackEntry(%q): expected to see %#v not be remapped", path, de.xattrs)
 				}
+			}
+
+			// We expect to get the exact same thing as the original archive
+			// entries in the new archive.
+			var wantDentries []tarDentry
+			for _, dentry := range dentries {
+				wantDentries = append(wantDentries, dentry.tarDentry)
+			}
+			testGenerateLayersForRoundTrip(t, dir, unpackOptions.WhiteoutMode, wantDentries)
+		})
+	}
+}
+
+func TestUnpackGenerateRoundTrip_MockedSELinux(t *testing.T) {
+	// For test purposes we add a fake forbidden attribute that an unprivileged
+	// user can easily write to (and thus we can test it). This is meant to be
+	// a stand-in for "security.selinux" or any other xattr that gets
+	// auto-applied and needs special handling with forbiddenXattrFilter{}.
+	const forbiddenTestXattr = "user.UMOCI.fake_selinux"
+	specialXattrs[forbiddenTestXattr] = forbiddenXattrFilter{}
+	defer delete(specialXattrs, forbiddenTestXattr)
+
+	// Make sure it actually is masked according to the filters.
+	filter, isSpecial := getXattrFilter(forbiddenTestXattr)
+	require.Truef(t, isSpecial, "getXattrFilter(%q) should return a filter", forbiddenTestXattr)
+	require.Equalf(t, forbiddenXattrFilter{}, filter, "getXattrFilter(%q) should return the forbidden filter", forbiddenTestXattr)
+	require.Truef(t, filter.MaskedOnDisk(OCIStandardWhiteout, forbiddenTestXattr), "getXattrFilter(%q).MaskedOnDisk should be true", forbiddenTestXattr)
+
+	dir := t.TempDir()
+
+	dentries := []struct {
+		tarDentry
+		autoXattrs map[string]string
+	}{
+		{
+			tarDentry{path: ".", ftype: tar.TypeDir, xattrs: map[string]string{
+				"user.dummy.xattr": "foobar",
+			}},
+			map[string]string{
+				forbiddenTestXattr: "rootdir",
+				// This should be auto-cleared because its not a masked xattr
+				// nor is it in the tar header.
+				"user.UMOCI.fake_nonmasked_xattr": "should get removed",
+			},
+		},
+		{
+			tarDentry{path: "foo/", ftype: tar.TypeDir, xattrs: map[string]string{
+				"user.dummy.xattr": "barbaz",
+			}},
+			map[string]string{
+				forbiddenTestXattr: "foodir",
+			},
+		},
+		{
+			tarDentry{path: "foo/bar", ftype: tar.TypeReg, contents: "file"},
+			map[string]string{
+				forbiddenTestXattr: "foobarfile",
+				// This should be auto-cleared because its not a masked xattr
+				// nor is it in the tar header.
+				"user.UMOCI.another_fake_nonmasked_xattr": "should also get removed",
+			},
+		},
+	}
+
+	for _, test := range []struct {
+		name   string
+		woType WhiteoutMode
+	}{
+		{"OverlayFSWhiteout", OverlayFSWhiteout},
+		{"OCIStandardWhiteout", OCIStandardWhiteout},
+	} {
+		test := test // copy iterator
+		t.Run(test.name, func(t *testing.T) {
+			unpackOptions := UnpackOptions{
+				MapOptions: MapOptions{
+					Rootless: os.Geteuid() != 0,
+				},
+				WhiteoutMode: test.woType,
+			}
+
+			te := NewTarExtractor(unpackOptions)
+
+			for _, de := range dentries {
+				hdr, rdr := tarFromDentry(de.tarDentry)
+				err := te.UnpackEntry(dir, hdr, rdr)
+				assert.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
+
+				// Apply the "auto" xattrs -- in order to make it seem like this
+				// was done automatically during extraction when the inode was
+				// created, we want to call applyMetadata here again to emulate
+				// this xattr being added by the system during UnpackEntry.
+				pth := filepath.Join(dir, de.path)
+				for xattr, value := range de.autoXattrs {
+					err := unix.Lsetxattr(pth, xattr, []byte(value), 0)
+					require.NoErrorf(t, err, "setxattr %s=%s on %q", xattr, value, hdr.Name)
+				}
+				err = te.restoreMetadata(pth, hdr)
+				require.NoErrorf(t, err, "restoreMetadata %s", hdr.Name)
+			}
+
+			for _, de := range dentries {
+				path := de.path
+				fullPath := filepath.Join(dir, path)
+
+				xattrs := getAllXattrs(t, fullPath)
+
+				wantXattrs := map[string]string{}
+				// We should see all of the hdr xattrs.
+				for xattr, value := range de.xattrs {
+					wantXattrs[xattr] = value
+				}
+				// Of the auto-applied xattrs, we only expect to see our dummy
+				// forbidden xattr after all the extractions.
+				if value, ok := de.autoXattrs[forbiddenTestXattr]; ok {
+					wantXattrs[forbiddenTestXattr] = value
+				}
+				assert.Equalf(t, wantXattrs, xattrs, "UnpackEntry(%q): expected to only see specific subset of applied xattrs", path)
 			}
 
 			// We expect to get the exact same thing as the original archive


### PR DESCRIPTION
We've had special handling of xattrs like security.selinux (which the
system auto-applies when inodes are created) for a very long time, but
commit 9a1cefaf16bf ("oci: layer: correctly handle trusted.overlay xattr
namespace escaping") accidentally broke this during a refactor.

The solution is to simply invert the filter.MaskedOnDisk check, but we
need to have some tests that simulate security.selinux to ensure we
don't make the same mistake again in the future.

Fixes #578 
Fixes: 9a1cefaf16bf ("oci: layer: correctly handle trusted.overlay xattr namespace escaping")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>