### PR TITLE
oci: layer: temporarily disallow overlayfs on-disk bundle unpacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   had no real impact on umoci but for safety we implemented the now-recommended
   media-type embedding and verification. CVE-2021-41190
 
+### Breaking ###
+- In [umoci 0.4.7](#0.4.7), we added support for overlayfs unpacking using the
+  still-unstable Go API. However, the implementation is still missing some key
+  features and so we will now return errors from APIs that are still missing
+  key features:
+
+   - `layer.UnpackManifest` and `layer.UnpackRootfs` will now return an error
+     if `UnpackOptions.WhiteoutMode` is set to anything other than
+     `OCIStandardWhiteout` (the default).
+
+     This is because bundle-based unpacking currently tries to unpack all
+     layers into the same `rootfs` and generate an `mtree` manifest -- this
+     doesn't make sense for overlayfs-style unpacking and will produce garbage
+     bundles as a result. As such, we expect that nobody actually made use of
+     this feature (otherwise we would've seen bug reports complaining about it
+     being completely broken in the past 4 years). [opencontainers/umoci#574][]
+     tracks re-enabling this feature (and exposing to umoci CLI users, if
+     possible).
+
+     *Note that `layer.UnpackLayer` still supports `OverlayFSWhiteout`.*
+
+  Users should expect more breaking changes in the overlayfs-related Go APIs in
+  a future umoci 0.6 release, as there is still a lot of work left to do.
+
 ### Added ###
 - `umoci unpack` now supports handling layers compressed with zstd. This is
   something that was added in image-spec v1.2 (which we do not yet support
@@ -115,6 +139,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   any other xattrs (this is in contrast to the previous behaviour where they
   would be silently ignored regardless of the on-disk format being used).
 
+[opencontainers/umoci#574]: https://github.com/opencontainers/umoci/issues/574
 [linux-overlayfs-escaping-dad02fad84cbc]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dad02fad84cbce30f317b69a4f2391f90045f79d
 
 ## [0.4.7] - 2021-04-05 ##

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
      *Note that `layer.UnpackLayer` still supports `OverlayFSWhiteout`.*
 
+   - Already-extracted bundles with `OverlayFSWhiteout` will now return an
+     error when umoci operates on them -- we included the whiteout mode in
+     our `umoci.json` but as the feature is broken, umoci will now refuse to
+     operate on such bundles. Such bundles could only have been created using
+     the now-error-inducing `UnpackRootfs` and `UnpackManifest` APIs mentioned
+     above, and as mentioned above we expect there to have been no real users
+     of this feature.
+
+     *Note that this only affects extracted bundles (a-la `umoci unpack`).*
+     Images created from such bundles are unaffected (even though their
+     contents probably should be audited, since the implementation of this
+     feature was quite broken in this usecase).
+
   Users should expect more breaking changes in the overlayfs-related Go APIs in
   a future umoci 0.6 release, as there is still a lot of work left to do.
 

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package internal
+
+import (
+	"errors"
+)
+
+var (
+	ErrUnimplemented = errors.New("unimplemented umoci feature")
+)

--- a/repack.go
+++ b/repack.go
@@ -106,11 +106,9 @@ func Repack(engineExt casext.Engine, tagName string, bundlePath string, meta Met
 			return err
 		}
 	} else {
-		packOptions := layer.RepackOptions{MapOptions: meta.MapOptions}
-		if meta.WhiteoutMode == layer.OverlayFSWhiteout {
-			packOptions.TranslateOverlayWhiteouts = true
-		}
-		reader, err := layer.GenerateLayer(fullRootfsPath, diffs, &packOptions)
+		reader, err := layer.GenerateLayer(fullRootfsPath, diffs, &layer.RepackOptions{
+			MapOptions: meta.MapOptions,
+		})
 		if err != nil {
 			return fmt.Errorf("generate diff layer: %w", err)
 		}

--- a/unpack.go
+++ b/unpack.go
@@ -34,10 +34,10 @@ import (
 
 // Unpack unpacks an image to the specified bundle path.
 func Unpack(engineExt casext.Engine, fromName string, bundlePath string, unpackOptions layer.UnpackOptions) error {
-	var meta Meta
-	meta.Version = MetaVersion
-	meta.MapOptions = unpackOptions.MapOptions
-	meta.WhiteoutMode = unpackOptions.WhiteoutMode
+	meta := Meta{
+		Version:    MetaVersion,
+		MapOptions: unpackOptions.MapOptions,
+	}
 
 	fromDescriptorPaths, err := engineExt.ResolveReference(context.Background(), fromName)
 	if err != nil {


### PR DESCRIPTION
We currently do not properly support this, and the results users get
will be completely broken. We can re-enable this in the future.

The only user of OverlayFSWhiteout is stacker, and they use UnpackLayer
explicitly (without using our bundle unpacking logic at all).

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>