### PR TITLE
oci: blobcompress: switch to Docker-friendly gzip block size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   cgroupv2 systems.
 - umoci has been migrated away from `github.com/pkg/errors` to Go stdlib error
   wrapping.
+- The gzip compression block size has been updated to be more friendly with
+  Docker and other tools that might round-trip the layer blob data (causing the
+  hash to change if the block size is different). #509
 
 ### Fixed ###
 - In 0.4.7, a performance regression was introduced as part of the


### PR DESCRIPTION
According to the stacker folks, having a parameter that mismatches with
Docker will result in layers getting recompressed. Based on my testing,
the hashes of random layer data doesn't change but I guess it's possible
it could change in certain situations and we should just match their
settings.

Ideally this would be configurable but since stacker is the only thing
that cares about this for the moment, we may as well just follow their
default setting (which -- it turns out -- is the new pgzip default
setting too).

Closes #509
Suggested-by: Ramkumar Chinchani <rchincha@cisco.com>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>