### PR TITLE
oci: layer: add support for userxattr in OverlayfsRootfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   (called `TranslateOverlayWhiteouts` in [umoci 0.4.7](#0.4.7)) now support
   converting `trusted.overlay.opaque=y` and `trusted.overlay.whiteout`
   whiteouts into OCI whiteouts when generating OCI layers.
+- `OverlayfsRootfs` now supports compatibility with the `userxattr` mount
+  option for overlayfs (where `user.overlay.*` xattrs are used rather than
+  the default `trusted.overlay.*`). This is a pretty key compatibility feature
+  for users that use unprivileged overlayfs mounts and will hopefully remove
+  the need for most downstream forks hacking in this functionality (such as
+  stacker). For Go API users, to enable this just set `UserXattr: true` in
+  `OverlayfsRootfs`. Note that (as with upstream overlayfs), only one xattr
+  namespace is ever used (so if `OverlayfsRootfs.UserXattr == true` then
+  `trusted.overlay.*` xattrs will be treated like any other non-overlayfs
+  xattr).
 
 ### Changes ###
 - In this release, the primary development branch was renamed to `main`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,76 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   media-type embedding and verification. CVE-2021-41190
 
 ### Breaking ###
+- The method of configuring the on-disk format and `MapOptions` in
+  `RepackOptions` and `UnpackOptions` has been changed. The on-disk format is
+  now represented with the `OnDiskFormat` interface, with `DirRootfs` and
+  `OverlayfsRootfs` as possible options to use. `MapOptions` is now configured
+  inside the `OnDiskFormat` setting, which will require callers to adjust their
+  usage of the main umoci APIs. In particular, examples like
+
+  ```go
+  unpackOptions := &layer.UnpackOptions{
+      MapOptions: mapOptions,
+      WhiteoutMode: layer.StandardOCIWhiteout, // or layer.OverlayFSWhiteout
+  }
+  err := layer.UnpackManifest(ctx, engineExt, bundle, manifest, unpackOptions)
+  ```
+
+  will have to now be written as
+
+  ```go
+  unpackOptions := &layer.UnpackOptions{
+      OnDiskFormat: layer.DirRootfs{ // or layer.OverlayfsRootfs
+          MapOptions: mapOptions,
+      },
+  }
+  err := layer.UnpackManifest(ctx, engineExt, bundle, manifest, unpackOptions)
+  ```
+
+  and similarly
+
+  ```go
+  repackOptions := &layer.RepackOptions{
+      MapOptions: mapOptions,
+      TranslateOverlayWhiteouts: false, // or true
+  }
+  layerRdr, err := layer.GenerateLayer(path, deltas, repackOptions)
+  ```
+
+  will have to now be written as
+
+  ```go
+  repackOptions := &layer.RepackOptions{
+      OnDiskFormat: layer.DirRootfs{ // or layer.OverlayfsRootfs
+          MapOptions: mapOptions,
+      },
+  }
+  layerRdr, err := layer.GenerateLayer(path, deltas, repackOptions)
+  ```
+
+  Note that this means you can easily re-use the `OnDiskFormat` configuration
+  between both `UnpackOptions` and `RepackOptions`, removing the previous need
+  to translate between `WhiteoutMode` and `TranslateOverlayWhiteouts`.
+
+  For users of the API that need to extract the `MapOptions` from
+  `UnpackOptions` and `RepackOptions`, there is a new helper `MapOptions` which
+  will help extract it without doing interface type switching. For
+  `OnDiskFormat` there is also a `Map` method that gives you the inner
+  `MapOptions` regardless of type.
+
+- `layer.NewTarExtractor` now takes `*UnpackOptions` rather than
+  `UnpackOptions` to match the signatures of the other `layer.*` APIs. Passing
+  `nil` is equivalent to passing `&UnpackOptions{}`.
+
 - In [umoci 0.4.7](#0.4.7), we added support for overlayfs unpacking using the
   still-unstable Go API. However, the implementation is still missing some key
   features and so we will now return errors from APIs that are still missing
   key features:
 
    - `layer.UnpackManifest` and `layer.UnpackRootfs` will now return an error
-     if `UnpackOptions.WhiteoutMode` is set to anything other than
-     `OCIStandardWhiteout` (the default).
+     if `UnpackOptions.OnDiskFormat` is set to anything other than `DirRootfs`
+     (the default, equivalent to `WhiteoutMode` being set to
+     `OCIStandardWhiteout` in [umoci 0.4.7](#0.4.7)).
 
      This is because bundle-based unpacking currently tries to unpack all
      layers into the same `rootfs` and generate an `mtree` manifest -- this
@@ -40,15 +102,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
      tracks re-enabling this feature (and exposing to umoci CLI users, if
      possible).
 
-     *Note that `layer.UnpackLayer` still supports `OverlayFSWhiteout`.*
+     *Note that `layer.UnpackLayer` still supports `OverlayfsRootfs`
+     (`OverlayFSWhiteout` in [umoci 0.4.7](#0.4.7)).*
 
-   - Already-extracted bundles with `OverlayFSWhiteout` will now return an
-     error when umoci operates on them -- we included the whiteout mode in
-     our `umoci.json` but as the feature is broken, umoci will now refuse to
-     operate on such bundles. Such bundles could only have been created using
-     the now-error-inducing `UnpackRootfs` and `UnpackManifest` APIs mentioned
-     above, and as mentioned above we expect there to have been no real users
-     of this feature.
+   - Already-extracted bundles with `OverlayfsRootfs` (`OverlayFSWhiteout` in
+     [umoci 0.4.7](#0.4.7)) will now return an error when umoci operates on
+     them -- we included the whiteout mode in our `umoci.json` but as the
+     feature is broken, umoci will now refuse to operate on such bundles. Such
+     bundles could only have been created using the now-error-inducing
+     `UnpackRootfs` and `UnpackManifest` APIs mentioned above, and as mentioned
+     above we expect there to have been no real users of this feature.
 
      *Note that this only affects extracted bundles (a-la `umoci unpack`).*
      Images created from such bundles are unaffected (even though their
@@ -71,10 +134,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     `--compress` flag. You can also disable compression entirely using
     `--compress=none` but `--compress=auto` will never automatically choose
     `none` compression.
-- `GenerateLayer` and `GenerateInsertLayer` with `TranslateOverlayWhiteouts`
-  now support converting `trusted.overlay.opaque=y` and
-  `trusted.overlay.whiteout` whiteouts into OCI whiteouts when generating OCI
-  layers.
+- `GenerateLayer` and `GenerateInsertLayer` with `OverlayfsRootfs`
+  (called `TranslateOverlayWhiteouts` in [umoci 0.4.7](#0.4.7)) now support
+  converting `trusted.overlay.opaque=y` and `trusted.overlay.whiteout`
+  whiteouts into OCI whiteouts when generating OCI layers.
 
 ### Changes ###
 - In this release, the primary development branch was renamed to `main`.
@@ -106,8 +169,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - umoci will now return an explicit error if you pass invalid uid or gid values
   to `--uid-map` and `--gid-map` rather than silently truncating the value.
 - For Go users of umoci, `GenerateLayer` (but not `GenerateInsertLayer`) with
-  the `TranslateOverlayWhiteouts` option enabled had several severe bugs that
-  made the feature unusable:
+  `OverlayfsRootfs` (called `TranslateOverlayWhiteouts` in [umoci
+  0.4.7](#0.4.7)) had several severe bugs that made the feature unusable:
   * All OCI whiteouts added to the archive would incorrectly have the full host
     name of the path rather than the correctly rooted path, making the whiteout
     practically useless.
@@ -117,7 +180,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the past 4 years, it seems this feature has not really been used by anyone (I
   hope...).
 - For Go users of umoci, `UnpackLayer` now correctly handles several aspects of
-  `OverlayFSWhiteout` extraction that weren't handled correctly:
+  `OverlayfsRootfs` (`OverlayFSWhiteout` in [umoci 0.4.7](#0.4.7)) extraction
+  that weren't handled correctly:
   * Unlike regular extractions, overlayfs-style extractions require us to
     create the parent directory of the whiteout (rather than ignoring or
     assuming the underlying path exists) because the whiteout is being created

--- a/cmd/umoci/insert.go
+++ b/cmd/umoci/insert.go
@@ -165,7 +165,11 @@ func insert(ctx *cli.Context) (Err error) {
 		return err
 	}
 
-	packOptions := layer.RepackOptions{MapOptions: meta.MapOptions}
+	packOptions := layer.RepackOptions{
+		OnDiskFormat: layer.DirRootfs{
+			MapOptions: meta.MapOptions,
+		},
+	}
 	reader := layer.GenerateInsertLayer(sourcePath, targetPath, ctx.IsSet("opaque"), &packOptions)
 	defer funchelpers.VerifyClose(&Err, reader)
 

--- a/cmd/umoci/raw-unpack.go
+++ b/cmd/umoci/raw-unpack.go
@@ -72,7 +72,6 @@ func rawUnpack(ctx *cli.Context) (Err error) {
 	fromName := mustFetchMeta[string](ctx, "--image-tag")
 	rootfsPath := mustFetchMeta[string](ctx, "rootfs")
 
-	var unpackOptions layer.UnpackOptions
 	var meta umoci.Meta
 	meta.Version = umoci.MetaVersion
 
@@ -83,8 +82,12 @@ func rawUnpack(ctx *cli.Context) (Err error) {
 		return err
 	}
 
-	unpackOptions.KeepDirlinks = ctx.Bool("keep-dirlinks")
-	unpackOptions.MapOptions = meta.MapOptions
+	unpackOptions := layer.UnpackOptions{
+		OnDiskFormat: layer.DirRootfs{
+			MapOptions: meta.MapOptions,
+		},
+		KeepDirlinks: ctx.Bool("keep-dirlinks"),
+	}
 
 	// Get a reference to the CAS.
 	engine, err := dir.Open(imagePath)

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -73,7 +73,6 @@ func unpack(ctx *cli.Context) (Err error) {
 	fromName := mustFetchMeta[string](ctx, "--image-tag")
 	bundlePath := mustFetchMeta[string](ctx, "bundle")
 
-	var unpackOptions layer.UnpackOptions
 	var meta umoci.Meta
 	meta.Version = umoci.MetaVersion
 
@@ -83,8 +82,12 @@ func unpack(ctx *cli.Context) (Err error) {
 		return err
 	}
 
-	unpackOptions.KeepDirlinks = ctx.Bool("keep-dirlinks")
-	unpackOptions.MapOptions = meta.MapOptions
+	unpackOptions := layer.UnpackOptions{
+		OnDiskFormat: layer.DirRootfs{
+			MapOptions: meta.MapOptions,
+		},
+		KeepDirlinks: ctx.Bool("keep-dirlinks"),
+	}
 
 	// Get a reference to the CAS.
 	engine, err := dir.Open(imagePath)

--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -54,7 +54,8 @@ const (
 	expectedManifestSize   int64         = 407
 )
 
-func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
+func setup(t *testing.T) (cas.Engine, ispec.Descriptor) {
+	dir := t.TempDir()
 	dir = filepath.Join(dir, "image")
 	err := casdir.Create(dir)
 	require.NoError(t, err)
@@ -151,9 +152,7 @@ func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
 }
 
 func TestMutateCache(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, fromDescriptor := setup(t, dir)
+	engine, fromDescriptor := setup(t)
 	defer engine.Close() //nolint:errcheck
 
 	mutator, err := New(engine, casext.DescriptorPath{Walk: []ispec.Descriptor{fromDescriptor}})
@@ -199,9 +198,7 @@ func TestMutateCache(t *testing.T) {
 }
 
 func TestMutateAdd(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, fromDescriptor := setup(t, dir)
+	engine, fromDescriptor := setup(t)
 	defer engine.Close() //nolint:errcheck
 
 	mutator, err := New(engine, casext.DescriptorPath{Walk: []ispec.Descriptor{fromDescriptor}})
@@ -313,9 +310,7 @@ func testMutateAddCompression(t *testing.T, mutator *Mutator, mediaType string, 
 }
 
 func TestMutateAddCompression(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, fromDescriptor := setup(t, dir)
+	engine, fromDescriptor := setup(t)
 	defer engine.Close() //nolint:errcheck
 
 	mutator, err := New(engine, casext.DescriptorPath{Walk: []ispec.Descriptor{fromDescriptor}})
@@ -367,9 +362,7 @@ func TestMutateAddCompression(t *testing.T) {
 }
 
 func TestMutateAddExisting(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, fromDescriptor := setup(t, dir)
+	engine, fromDescriptor := setup(t)
 	defer engine.Close() //nolint:errcheck
 
 	mutator, err := New(engine, casext.DescriptorPath{Walk: []ispec.Descriptor{fromDescriptor}})
@@ -417,9 +410,7 @@ func TestMutateAddExisting(t *testing.T) {
 }
 
 func TestMutateSet(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, fromDescriptor := setup(t, dir)
+	engine, fromDescriptor := setup(t)
 	defer engine.Close() //nolint:errcheck
 
 	mutator, err := New(engine, casext.DescriptorPath{Walk: []ispec.Descriptor{fromDescriptor}})
@@ -463,9 +454,7 @@ func TestMutateSet(t *testing.T) {
 }
 
 func TestMutateSetNoHistory(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, fromDescriptor := setup(t, dir)
+	engine, fromDescriptor := setup(t)
 	defer engine.Close() //nolint:errcheck
 
 	mutator, err := New(engine, casext.DescriptorPath{Walk: []ispec.Descriptor{fromDescriptor}})
@@ -522,9 +511,7 @@ func walkDescriptorRoot(ctx context.Context, engine casext.Engine, root ispec.De
 }
 
 func TestMutatePath(t *testing.T) {
-	dir := t.TempDir()
-
-	engine, manifestDescriptor := setup(t, dir)
+	engine, manifestDescriptor := setup(t)
 	engineExt := casext.NewEngine(engine)
 	defer engine.Close() //nolint:errcheck
 

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -45,14 +45,13 @@ func (ids inodeDeltas) Swap(i, j int)      { ids[i], ids[j] = ids[j], ids[i] }
 // returned reader is for the *raw* tar data, it is the caller's responsibility
 // to gzip it.
 func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (io.ReadCloser, error) {
-	var packOptions RepackOptions
-	if opt != nil {
-		packOptions = *opt
-	}
+	opt = opt.fill()
+
 	fsEval := fseval.Default
-	if packOptions.MapOptions.Rootless {
+	if opt.MapOptions().Rootless {
 		fsEval = fseval.Rootless
 	}
+	_, translateOverlayWhiteouts := opt.OnDiskFormat.(OverlayfsRootfs)
 
 	reader, writer := io.Pipe()
 
@@ -70,7 +69,7 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 		// We can't just dump all of the file contents into a tar file. We need
 		// to emulate a proper tar generator. Luckily there aren't that many
 		// things to emulate (and we can do them all in tar.go).
-		tg := newTarGenerator(writer, packOptions)
+		tg := newTarGenerator(writer, opt)
 
 		// Sort the delta paths.
 		// FIXME: We need to add whiteouts first, otherwise we might end up
@@ -88,7 +87,7 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 
 			switch delta.Type() {
 			case mtree.Modified, mtree.Extra:
-				if packOptions.TranslateOverlayWhiteouts {
+				if translateOverlayWhiteouts {
 					woType, isWo, err := isOverlayWhiteout(fullPath, fsEval)
 					if err != nil {
 						return fmt.Errorf("check if %q is a whiteout: %w", fullPath, err)
@@ -157,15 +156,13 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 // inside the directory), followed by the contents of the root.
 func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) io.ReadCloser {
 	root = CleanPath(root)
+	opt = opt.fill()
 
-	var packOptions RepackOptions
-	if opt != nil {
-		packOptions = *opt
-	}
 	fsEval := fseval.Default
-	if packOptions.MapOptions.Rootless {
+	if opt.MapOptions().Rootless {
 		fsEval = fseval.Rootless
 	}
+	_, translateOverlayWhiteouts := opt.OnDiskFormat.(OverlayfsRootfs)
 
 	reader, writer := io.Pipe()
 
@@ -179,7 +176,7 @@ func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) i
 			_ = writer.CloseWithError(closeErr)
 		}()
 
-		tg := newTarGenerator(writer, packOptions)
+		tg := newTarGenerator(writer, opt)
 
 		defer func() {
 			if err := tg.tw.Close(); err != nil {
@@ -207,7 +204,7 @@ func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) i
 			}
 			name := filepath.Join(target, relName)
 
-			if packOptions.TranslateOverlayWhiteouts {
+			if translateOverlayWhiteouts {
 				woType, isWo, err := isOverlayWhiteout(fullPath, fsEval)
 				if err != nil {
 					return fmt.Errorf("check if %q is a whiteout: %w", fullPath, err)

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -51,7 +51,6 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 	if opt.MapOptions().Rootless {
 		fsEval = fseval.Rootless
 	}
-	_, translateOverlayWhiteouts := opt.OnDiskFormat.(OverlayfsRootfs)
 
 	reader, writer := io.Pipe()
 
@@ -87,8 +86,8 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *RepackOptions) (
 
 			switch delta.Type() {
 			case mtree.Modified, mtree.Extra:
-				if translateOverlayWhiteouts {
-					woType, isWo, err := isOverlayWhiteout(fullPath, fsEval)
+				if onDiskFmt, isOverlayfs := opt.OnDiskFormat.(OverlayfsRootfs); isOverlayfs {
+					woType, isWo, err := isOverlayWhiteout(onDiskFmt, fullPath, fsEval)
 					if err != nil {
 						return fmt.Errorf("check if %q is a whiteout: %w", fullPath, err)
 					}
@@ -162,7 +161,6 @@ func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) i
 	if opt.MapOptions().Rootless {
 		fsEval = fseval.Rootless
 	}
-	_, translateOverlayWhiteouts := opt.OnDiskFormat.(OverlayfsRootfs)
 
 	reader, writer := io.Pipe()
 
@@ -204,8 +202,8 @@ func GenerateInsertLayer(root, target string, opaque bool, opt *RepackOptions) i
 			}
 			name := filepath.Join(target, relName)
 
-			if translateOverlayWhiteouts {
-				woType, isWo, err := isOverlayWhiteout(fullPath, fsEval)
+			if onDiskFmt, isOverlayfs := opt.OnDiskFormat.(OverlayfsRootfs); isOverlayfs {
+				woType, isWo, err := isOverlayWhiteout(onDiskFmt, fullPath, fsEval)
 				if err != nil {
 					return fmt.Errorf("check if %q is a whiteout: %w", fullPath, err)
 				}

--- a/oci/layer/generate_linux_test.go
+++ b/oci/layer/generate_linux_test.go
@@ -45,7 +45,7 @@ func TestTranslateOverlayWhiteouts_Char00(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, "reg"), []byte("dummy file"), 0o644)
 	require.NoError(t, err)
 
-	packOptions := RepackOptions{TranslateOverlayWhiteouts: true}
+	packOptions := RepackOptions{OnDiskFormat: OverlayfsRootfs{}}
 
 	t.Run("GenerateLayer", func(t *testing.T) {
 		// something reasonable
@@ -94,7 +94,7 @@ func TestTranslateOverlayWhiteouts_XattrOpaque(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, "reg"), []byte("dummy file"), 0o644)
 	require.NoError(t, err)
 
-	packOptions := RepackOptions{TranslateOverlayWhiteouts: true}
+	packOptions := RepackOptions{OnDiskFormat: OverlayfsRootfs{}}
 
 	t.Run("GenerateLayer", func(t *testing.T) {
 		// something reasonable
@@ -145,7 +145,7 @@ func TestTranslateOverlayWhiteouts_XattrWhiteout(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, "reg"), []byte("dummy file"), 0o644)
 	require.NoError(t, err)
 
-	packOptions := RepackOptions{TranslateOverlayWhiteouts: true}
+	packOptions := RepackOptions{OnDiskFormat: OverlayfsRootfs{}}
 
 	t.Run("GenerateLayer", func(t *testing.T) {
 		// something reasonable

--- a/oci/layer/layer_fuzzer.go
+++ b/oci/layer/layer_fuzzer.go
@@ -300,16 +300,18 @@ func FuzzUnpack(data []byte) int {
 	}
 	defer os.RemoveAll(bundle) //nolint:errcheck
 
-	unpackOptions := &UnpackOptions{MapOptions: MapOptions{
-		UIDMappings: []rspec.LinuxIDMapping{
-			{HostID: uint32(os.Geteuid()), ContainerID: 0, Size: 1},
-			{HostID: uint32(os.Geteuid()), ContainerID: 1000, Size: 1},
+	unpackOptions := &UnpackOptions{OnDiskFormat: DirRootfs{
+		MapOptions: MapOptions{
+			UIDMappings: []rspec.LinuxIDMapping{
+				{HostID: uint32(os.Geteuid()), ContainerID: 0, Size: 1},
+				{HostID: uint32(os.Geteuid()), ContainerID: 1000, Size: 1},
+			},
+			GIDMappings: []rspec.LinuxIDMapping{
+				{HostID: uint32(os.Getegid()), ContainerID: 0, Size: 1},
+				{HostID: uint32(os.Getegid()), ContainerID: 100, Size: 1},
+			},
+			Rootless: os.Geteuid() != 0,
 		},
-		GIDMappings: []rspec.LinuxIDMapping{
-			{HostID: uint32(os.Getegid()), ContainerID: 0, Size: 1},
-			{HostID: uint32(os.Getegid()), ContainerID: 100, Size: 1},
-		},
-		Rootless: os.Geteuid() != 0,
 	}}
 
 	called := false

--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -196,7 +196,7 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 		// when in overlayfs mode) to have correct values.
 		mappedName := xattr
 		if filter, isSpecial := getXattrFilter(xattr); isSpecial {
-			if newName := filter.ToDisk(te.onDiskFmt, xattr); newName == nil {
+			if newName := filter.ToDisk(te.onDiskFmt, xattr); newName == "" {
 				// Avoid outputting a warning if a must-skip xattr already has
 				// the expected value we wanted.
 				//
@@ -212,8 +212,8 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 				}
 				log.Warnf("xattr{%s} ignoring forbidden xattr %q", hdr.Name, xattr)
 				continue
-			} else if *newName != xattr {
-				mappedName = *newName
+			} else if newName != xattr {
+				mappedName = newName
 				log.Debugf("xattr{%s} remapping xattr %q to %q during extraction", hdr.Name, xattr, mappedName)
 			}
 		}
@@ -575,7 +575,7 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 				// we don't need to provide any user warnings.
 				mappedName := xattr
 				if filter, isSpecial := getXattrFilter(xattr); isSpecial {
-					if newName := filter.ToTar(te.onDiskFmt, xattr); newName == nil {
+					if newName := filter.ToTar(te.onDiskFmt, xattr); newName == "" {
 						log.Debugf("xattr{%s} ignoring masked xattr %q while generating fake parent directory header for restoreMetadata", unsafeDir, xattr)
 						// If the xattr should be ignored we can safely skip it
 						// here because MaskedOnDisk will also stop them from
@@ -588,8 +588,8 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 							log.Fatalf("[internal error] xattr{%s} masked %q is being hidden by (%T).GenerateEntry but UnpackShouldClear returns true", unsafeDir, xattr, filter)
 						}
 						continue
-					} else if *newName != xattr {
-						mappedName = *newName
+					} else if newName != xattr {
+						mappedName = newName
 						log.Debugf("xattr{%s} remapping xattr %q to %q for later restoreMetadata", unsafeDir, xattr, mappedName)
 					}
 				}

--- a/oci/layer/tar_extract_linux_test.go
+++ b/oci/layer/tar_extract_linux_test.go
@@ -25,6 +25,7 @@ package layer
 import (
 	"archive/tar"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,20 +59,21 @@ func testNeedsTrustedOverlayXattrs(t *testing.T) {
 	require.NoError(t, err, "setxattr trusted.overlay.opaque should succeed or error with ErrPermission")
 }
 
-func assertIsPlainWhiteout(t *testing.T, path string) {
-	woType, isWo, err := isOverlayWhiteout(path, fseval.Default)
-	require.NoErrorf(t, err, "isOverlayWhiteout(%q)", path)
+func assertIsPlainWhiteout(t *testing.T, onDiskFmt OverlayfsRootfs, path string) {
+	woType, isWo, err := isOverlayWhiteout(onDiskFmt, path, fseval.Default)
+	require.NoErrorf(t, err, "isOverlayWhiteout({UserXattr: %v}, %q)", onDiskFmt.UserXattr, path)
 	assert.True(t, isWo, "extract should make overlay whiteout")
 	assert.Equal(t, overlayWhiteoutPlain, woType, "extract should make a plain whiteout")
 }
 
-func assertIsOpaqueWhiteout(t *testing.T, path string) {
-	val, err := system.Lgetxattr(path, "trusted.overlay.opaque")
+func assertIsOpaqueWhiteout(t *testing.T, onDiskFmt OverlayfsRootfs, path string) {
+	opaqueXattr := onDiskFmt.xattr("opaque")
+	val, err := system.Lgetxattr(path, opaqueXattr)
 	require.NoErrorf(t, err, "get overlay opaque attr for %q", path)
 	assert.Equalf(t, "y", string(val), "bad opaque attr for %q", path)
 
-	woType, isWo, err := isOverlayWhiteout(path, fseval.Default)
-	require.NoErrorf(t, err, "isOverlayWhiteout(%q)", path)
+	woType, isWo, err := isOverlayWhiteout(onDiskFmt, path, fseval.Default)
+	require.NoErrorf(t, err, "isOverlayWhiteout({UserXattr: %v}, %q)", onDiskFmt.UserXattr, path)
 	assert.Truef(t, isWo, "extract should make %q an overlay whiteout", path)
 	assert.Equalf(t, overlayWhiteoutOpaque, woType, "extract should make %q an opaque whiteout", path)
 }
@@ -82,144 +84,185 @@ func assertNoPathExists(t *testing.T, path string) {
 }
 
 func TestUnpackEntry_OverlayfsRootfs_Whiteout(t *testing.T) {
-	dir := t.TempDir()
-
 	testNeedsMknod(t)
 
-	dentries := []tarDentry{
-		{path: "file", ftype: tar.TypeReg},
-		{path: whPrefix + "file", ftype: tar.TypeReg},
-	}
+	for _, userxattr := range []bool{true, false} {
+		userxattr := userxattr // copy iterator
+		t.Run(fmt.Sprintf("UserXattr=%v", userxattr), func(t *testing.T) {
+			dir := t.TempDir()
 
-	unpackOptions := UnpackOptions{
-		OnDiskFormat: OverlayfsRootfs{
-			MapOptions: MapOptions{
-				Rootless: os.Geteuid() != 0,
-			},
-		},
-	}
-	te := NewTarExtractor(&unpackOptions)
+			onDiskFmt := OverlayfsRootfs{
+				MapOptions: MapOptions{
+					Rootless: os.Geteuid() != 0,
+				},
+				UserXattr: userxattr,
+			}
 
-	for _, de := range dentries {
-		hdr, rdr := tarFromDentry(de)
-		err := te.UnpackEntry(dir, hdr, rdr)
-		require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
-	}
+			dentries := []tarDentry{
+				{path: "file", ftype: tar.TypeReg},
+				{path: whPrefix + "file", ftype: tar.TypeReg},
+			}
 
-	assertIsPlainWhiteout(t, filepath.Join(dir, "file"))
+			unpackOptions := UnpackOptions{
+				OnDiskFormat: onDiskFmt,
+			}
+			te := NewTarExtractor(&unpackOptions)
+
+			for _, de := range dentries {
+				hdr, rdr := tarFromDentry(de)
+				err := te.UnpackEntry(dir, hdr, rdr)
+				require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
+			}
+
+			assertIsPlainWhiteout(t, onDiskFmt, filepath.Join(dir, "file"))
+		})
+	}
 }
 
 func TestUnpackEntry_OverlayfsRootfs_OpaqueWhiteout(t *testing.T) {
-	dir := t.TempDir()
-
 	testNeedsMknod(t)
-	testNeedsTrustedOverlayXattrs(t)
 
-	dentries := []tarDentry{
-		{path: "dir", ftype: tar.TypeDir},
-		{path: "dir/fileindir", ftype: tar.TypeReg},
-		{path: "dir/" + whOpaque, ftype: tar.TypeReg},
+	for _, userxattr := range []bool{true, false} {
+		userxattr := userxattr // copy iterator
+		t.Run(fmt.Sprintf("UserXattr=%v", userxattr), func(t *testing.T) {
+			dir := t.TempDir()
+
+			if !userxattr {
+				testNeedsTrustedOverlayXattrs(t)
+			}
+
+			onDiskFmt := OverlayfsRootfs{
+				MapOptions: MapOptions{
+					Rootless: os.Geteuid() != 0,
+				},
+				UserXattr: userxattr,
+			}
+
+			dentries := []tarDentry{
+				{path: "dir", ftype: tar.TypeDir},
+				{path: "dir/fileindir", ftype: tar.TypeReg},
+				{path: "dir/" + whOpaque, ftype: tar.TypeReg},
+			}
+
+			unpackOptions := UnpackOptions{
+				OnDiskFormat: onDiskFmt,
+			}
+			te := NewTarExtractor(&unpackOptions)
+
+			for _, de := range dentries {
+				hdr, rdr := tarFromDentry(de)
+				err := te.UnpackEntry(dir, hdr, rdr)
+				require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
+			}
+
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "dir"))
+		})
 	}
-
-	unpackOptions := UnpackOptions{
-		OnDiskFormat: OverlayfsRootfs{
-			MapOptions: MapOptions{
-				Rootless: os.Geteuid() != 0,
-			},
-		},
-	}
-	te := NewTarExtractor(&unpackOptions)
-
-	for _, de := range dentries {
-		hdr, rdr := tarFromDentry(de)
-		err := te.UnpackEntry(dir, hdr, rdr)
-		require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
-	}
-
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "dir"))
 }
 
 func TestUnpackEntry_OverlayfsRootfs_Whiteout_MissingDirs(t *testing.T) {
-	dir := t.TempDir()
-
 	testNeedsMknod(t)
-	testNeedsTrustedOverlayXattrs(t)
 
-	dentries := []tarDentry{
-		// entry with no parent directory entries
-		{path: "opaque-noparent/a/b/c/" + whOpaque, ftype: tar.TypeReg},
-		{path: "whiteout-noparent/a/b/" + whPrefix + "c", ftype: tar.TypeReg},
-		// implicitly changing the type with an opaque dir
-		{path: "opaque-nondir", ftype: tar.TypeReg},
-		{path: "opaque-nondir/" + whOpaque, ftype: tar.TypeReg},
-		// plain whiteout converted to opaque dir
-		{path: whPrefix + "opaque-whiteout", ftype: tar.TypeReg},
-		{path: "opaque-whiteout/" + whOpaque, ftype: tar.TypeReg},
+	for _, userxattr := range []bool{true, false} {
+		userxattr := userxattr // copy iterator
+		t.Run(fmt.Sprintf("UserXattr=%v", userxattr), func(t *testing.T) {
+			dir := t.TempDir()
+
+			if !userxattr {
+				testNeedsTrustedOverlayXattrs(t)
+			}
+
+			onDiskFmt := OverlayfsRootfs{
+				MapOptions: MapOptions{
+					Rootless: os.Geteuid() != 0,
+				},
+				UserXattr: userxattr,
+			}
+
+			dentries := []tarDentry{
+				// entry with no parent directory entries
+				{path: "opaque-noparent/a/b/c/" + whOpaque, ftype: tar.TypeReg},
+				{path: "whiteout-noparent/a/b/" + whPrefix + "c", ftype: tar.TypeReg},
+				// implicitly changing the type with an opaque dir
+				{path: "opaque-nondir", ftype: tar.TypeReg},
+				{path: "opaque-nondir/" + whOpaque, ftype: tar.TypeReg},
+				// plain whiteout converted to opaque dir
+				{path: whPrefix + "opaque-whiteout", ftype: tar.TypeReg},
+				{path: "opaque-whiteout/" + whOpaque, ftype: tar.TypeReg},
+			}
+
+			unpackOptions := UnpackOptions{
+				OnDiskFormat: onDiskFmt,
+			}
+			te := NewTarExtractor(&unpackOptions)
+
+			for _, de := range dentries {
+				hdr, rdr := tarFromDentry(de)
+				err := te.UnpackEntry(dir, hdr, rdr)
+				require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
+			}
+
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-noparent/a/b/c"))
+			assertIsPlainWhiteout(t, onDiskFmt, filepath.Join(dir, "whiteout-noparent/a/b/c"))
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-nondir"))
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-whiteout"))
+		})
 	}
-
-	unpackOptions := UnpackOptions{
-		OnDiskFormat: OverlayfsRootfs{
-			MapOptions: MapOptions{
-				Rootless: os.Geteuid() != 0,
-			},
-		},
-	}
-	te := NewTarExtractor(&unpackOptions)
-
-	for _, de := range dentries {
-		hdr, rdr := tarFromDentry(de)
-		err := te.UnpackEntry(dir, hdr, rdr)
-		require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
-	}
-
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-noparent/a/b/c"))
-	assertIsPlainWhiteout(t, filepath.Join(dir, "whiteout-noparent/a/b/c"))
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-nondir"))
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-whiteout"))
 }
 
 func TestUnpackEntry_OverlayfsRootfs_Whiteout_Nested(t *testing.T) {
-	dir := t.TempDir()
-
 	testNeedsMknod(t)
-	testNeedsTrustedOverlayXattrs(t)
 
-	dentries := []tarDentry{
-		// make sure that whiteouts before and after are all missing from the
-		// final layer
-		{path: "opaque-innerplain/foo/bar/baz/" + whPrefix + "before", ftype: tar.TypeReg},
-		{path: "opaque-innerplain/regfile", ftype: tar.TypeReg},
-		{path: "opaque-innerplain/" + whOpaque, ftype: tar.TypeReg},
-		{path: "opaque-innerplain/a/b/c/d/e/f/" + whPrefix + "after", ftype: tar.TypeReg},
-		{path: "opaque-innerplain/a/b/c/d/regfile", ftype: tar.TypeReg},
-		// nested opaque directories should stay opaque
-		{path: "opaque-nested/a/b/c/d/" + whOpaque, ftype: tar.TypeReg},
-		{path: "opaque-nested/a/b/" + whOpaque, ftype: tar.TypeReg},
-		{path: "opaque-nested/" + whOpaque, ftype: tar.TypeReg},
+	for _, userxattr := range []bool{true, false} {
+		userxattr := userxattr // copy iterator
+		t.Run(fmt.Sprintf("UserXattr=%v", userxattr), func(t *testing.T) {
+			dir := t.TempDir()
+
+			if !userxattr {
+				testNeedsTrustedOverlayXattrs(t)
+			}
+
+			onDiskFmt := OverlayfsRootfs{
+				MapOptions: MapOptions{
+					Rootless: os.Geteuid() != 0,
+				},
+				UserXattr: userxattr,
+			}
+
+			dentries := []tarDentry{
+				// make sure that whiteouts before and after are all missing from the
+				// final layer
+				{path: "opaque-innerplain/foo/bar/baz/" + whPrefix + "before", ftype: tar.TypeReg},
+				{path: "opaque-innerplain/regfile", ftype: tar.TypeReg},
+				{path: "opaque-innerplain/" + whOpaque, ftype: tar.TypeReg},
+				{path: "opaque-innerplain/a/b/c/d/e/f/" + whPrefix + "after", ftype: tar.TypeReg},
+				{path: "opaque-innerplain/a/b/c/d/regfile", ftype: tar.TypeReg},
+				// nested opaque directories should stay opaque
+				{path: "opaque-nested/a/b/c/d/" + whOpaque, ftype: tar.TypeReg},
+				{path: "opaque-nested/a/b/" + whOpaque, ftype: tar.TypeReg},
+				{path: "opaque-nested/" + whOpaque, ftype: tar.TypeReg},
+			}
+
+			unpackOptions := UnpackOptions{
+				OnDiskFormat: onDiskFmt,
+			}
+			te := NewTarExtractor(&unpackOptions)
+
+			for _, de := range dentries {
+				hdr, rdr := tarFromDentry(de)
+				err := te.UnpackEntry(dir, hdr, rdr)
+				require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
+			}
+
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-innerplain"))
+			assertNoPathExists(t, filepath.Join(dir, "opaque-innerplain/foo/bar/baz/before"))
+			assertNoPathExists(t, filepath.Join(dir, "opaque-innerplain/a/b/c/d/e/f/after"))
+			assert.FileExists(t, filepath.Join(dir, "opaque-innerplain/a/b/c/d/regfile"))
+			assert.FileExists(t, filepath.Join(dir, "opaque-innerplain/regfile"))
+
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-nested"))
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-nested/a/b"))
+			assertIsOpaqueWhiteout(t, onDiskFmt, filepath.Join(dir, "opaque-nested/a/b/c/d"))
+		})
 	}
-
-	unpackOptions := UnpackOptions{
-		OnDiskFormat: OverlayfsRootfs{
-			MapOptions: MapOptions{
-				Rootless: os.Geteuid() != 0,
-			},
-		},
-	}
-	te := NewTarExtractor(&unpackOptions)
-
-	for _, de := range dentries {
-		hdr, rdr := tarFromDentry(de)
-		err := te.UnpackEntry(dir, hdr, rdr)
-		require.NoErrorf(t, err, "UnpackEntry %s", hdr.Name)
-	}
-
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-innerplain"))
-	assertNoPathExists(t, filepath.Join(dir, "opaque-innerplain/foo/bar/baz/before"))
-	assertNoPathExists(t, filepath.Join(dir, "opaque-innerplain/a/b/c/d/e/f/after"))
-	assert.FileExists(t, filepath.Join(dir, "opaque-innerplain/a/b/c/d/regfile"))
-	assert.FileExists(t, filepath.Join(dir, "opaque-innerplain/regfile"))
-
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-nested"))
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-nested/a/b"))
-	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-nested/a/b/c/d"))
 }

--- a/oci/layer/tar_extract_linux_test.go
+++ b/oci/layer/tar_extract_linux_test.go
@@ -81,7 +81,7 @@ func assertNoPathExists(t *testing.T, path string) {
 	assert.ErrorIsf(t, err, os.ErrNotExist, "path %q should not have existed", path)
 }
 
-func TestUnpackEntry_OverlayFSWhiteout(t *testing.T) {
+func TestUnpackEntry_OverlayfsRootfs_Whiteout(t *testing.T) {
 	dir := t.TempDir()
 
 	testNeedsMknod(t)
@@ -92,13 +92,13 @@ func TestUnpackEntry_OverlayFSWhiteout(t *testing.T) {
 	}
 
 	unpackOptions := UnpackOptions{
-		MapOptions: MapOptions{
-			Rootless: os.Geteuid() != 0,
+		OnDiskFormat: OverlayfsRootfs{
+			MapOptions: MapOptions{
+				Rootless: os.Geteuid() != 0,
+			},
 		},
-		WhiteoutMode: OverlayFSWhiteout,
 	}
-
-	te := NewTarExtractor(unpackOptions)
+	te := NewTarExtractor(&unpackOptions)
 
 	for _, de := range dentries {
 		hdr, rdr := tarFromDentry(de)
@@ -109,7 +109,7 @@ func TestUnpackEntry_OverlayFSWhiteout(t *testing.T) {
 	assertIsPlainWhiteout(t, filepath.Join(dir, "file"))
 }
 
-func TestUnpackEntry_OverlayFSOpaqueWhiteout(t *testing.T) {
+func TestUnpackEntry_OverlayfsRootfs_OpaqueWhiteout(t *testing.T) {
 	dir := t.TempDir()
 
 	testNeedsMknod(t)
@@ -122,13 +122,13 @@ func TestUnpackEntry_OverlayFSOpaqueWhiteout(t *testing.T) {
 	}
 
 	unpackOptions := UnpackOptions{
-		MapOptions: MapOptions{
-			Rootless: os.Geteuid() != 0,
+		OnDiskFormat: OverlayfsRootfs{
+			MapOptions: MapOptions{
+				Rootless: os.Geteuid() != 0,
+			},
 		},
-		WhiteoutMode: OverlayFSWhiteout,
 	}
-
-	te := NewTarExtractor(unpackOptions)
+	te := NewTarExtractor(&unpackOptions)
 
 	for _, de := range dentries {
 		hdr, rdr := tarFromDentry(de)
@@ -139,7 +139,7 @@ func TestUnpackEntry_OverlayFSOpaqueWhiteout(t *testing.T) {
 	assertIsOpaqueWhiteout(t, filepath.Join(dir, "dir"))
 }
 
-func TestUnpackEntry_OverlayFSWhiteout_MissingDirs(t *testing.T) {
+func TestUnpackEntry_OverlayfsRootfs_Whiteout_MissingDirs(t *testing.T) {
 	dir := t.TempDir()
 
 	testNeedsMknod(t)
@@ -158,13 +158,13 @@ func TestUnpackEntry_OverlayFSWhiteout_MissingDirs(t *testing.T) {
 	}
 
 	unpackOptions := UnpackOptions{
-		MapOptions: MapOptions{
-			Rootless: os.Geteuid() != 0,
+		OnDiskFormat: OverlayfsRootfs{
+			MapOptions: MapOptions{
+				Rootless: os.Geteuid() != 0,
+			},
 		},
-		WhiteoutMode: OverlayFSWhiteout,
 	}
-
-	te := NewTarExtractor(unpackOptions)
+	te := NewTarExtractor(&unpackOptions)
 
 	for _, de := range dentries {
 		hdr, rdr := tarFromDentry(de)
@@ -178,7 +178,7 @@ func TestUnpackEntry_OverlayFSWhiteout_MissingDirs(t *testing.T) {
 	assertIsOpaqueWhiteout(t, filepath.Join(dir, "opaque-whiteout"))
 }
 
-func TestUnpackEntry_OverlayFSWhiteout_Nested(t *testing.T) {
+func TestUnpackEntry_OverlayfsRootfs_Whiteout_Nested(t *testing.T) {
 	dir := t.TempDir()
 
 	testNeedsMknod(t)
@@ -199,13 +199,13 @@ func TestUnpackEntry_OverlayFSWhiteout_Nested(t *testing.T) {
 	}
 
 	unpackOptions := UnpackOptions{
-		MapOptions: MapOptions{
-			Rootless: os.Geteuid() != 0,
+		OnDiskFormat: OverlayfsRootfs{
+			MapOptions: MapOptions{
+				Rootless: os.Geteuid() != 0,
+			},
 		},
-		WhiteoutMode: OverlayFSWhiteout,
 	}
-
-	te := NewTarExtractor(unpackOptions)
+	te := NewTarExtractor(&unpackOptions)
 
 	for _, de := range dentries {
 		hdr, rdr := tarFromDentry(de)

--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -180,11 +180,11 @@ func (tg *tarGenerator) AddFile(name, path string) (Err error) {
 		// when in overlayfs mode) to have correct values.
 		mappedName := xattr
 		if filter, isSpecial := getXattrFilter(xattr); isSpecial {
-			if newName := filter.ToTar(tg.onDiskFmt, xattr); newName == nil {
+			if newName := filter.ToTar(tg.onDiskFmt, xattr); newName == "" {
 				log.Debugf("xattr{%s} skipping the inclusion of xattr %q in generated tar archive", hdr.Name, xattr)
 				continue
-			} else if *newName != xattr {
-				mappedName = *newName
+			} else if newName != xattr {
+				mappedName = newName
 				log.Debugf("xattr{%s} remapping xattr %q to %q in generated tar archive", hdr.Name, xattr, mappedName)
 			}
 		}

--- a/oci/layer/tar_generate_test.go
+++ b/oci/layer/tar_generate_test.go
@@ -53,13 +53,13 @@ func TestTarGenerateAddFileNormal(t *testing.T) {
 		Size:       int64(len(data)),
 	}
 
-	te := NewTarExtractor(UnpackOptions{})
+	te := NewTarExtractor(nil)
 	err := os.WriteFile(path, data, 0o777)
 	require.NoError(t, err)
 	err = te.applyMetadata(path, expectedHdr)
 	require.NoError(t, err, "apply metadata")
 
-	tg := newTarGenerator(writer, RepackOptions{})
+	tg := newTarGenerator(writer, nil)
 	tr := tar.NewReader(reader)
 
 	// Create all of the tar entries in a goroutine so we can parse the tar
@@ -122,13 +122,13 @@ func TestTarGenerateAddFileDirectory(t *testing.T) {
 		Size:       0,
 	}
 
-	te := NewTarExtractor(UnpackOptions{})
+	te := NewTarExtractor(nil)
 	err := os.Mkdir(path, 0o777)
 	require.NoError(t, err)
 	err = te.applyMetadata(path, expectedHdr)
 	require.NoError(t, err, "apply metadata")
 
-	tg := newTarGenerator(writer, RepackOptions{})
+	tg := newTarGenerator(writer, nil)
 	tr := tar.NewReader(reader)
 
 	// Create all of the tar entries in a goroutine so we can parse the tar
@@ -192,13 +192,13 @@ func TestTarGenerateAddFileSymlink(t *testing.T) {
 		Size:       0,
 	}
 
-	te := NewTarExtractor(UnpackOptions{})
+	te := NewTarExtractor(nil)
 	err := os.Symlink(linkname, path)
 	require.NoError(t, err)
 	err = te.applyMetadata(path, expectedHdr)
 	require.NoError(t, err, "apply metadata")
 
-	tg := newTarGenerator(writer, RepackOptions{})
+	tg := newTarGenerator(writer, nil)
 	tr := tar.NewReader(reader)
 
 	// Create all of the tar entries in a goroutine so we can parse the tar
@@ -262,7 +262,7 @@ func TestTarGenerateAddWhiteout(t *testing.T) {
 		"dir/.",
 	}
 
-	tg := newTarGenerator(writer, RepackOptions{})
+	tg := newTarGenerator(writer, nil)
 	tr := tar.NewReader(reader)
 
 	// Create all of the whiteout entries in a goroutine so we can parse the

--- a/oci/layer/types.go
+++ b/oci/layer/types.go
@@ -20,31 +20,95 @@ package layer
 
 import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	rspec "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-// TODO: Move away from separate WhiteoutMode and TranslateOverlayWhiteouts
-// configurations to a single "OnDiskFormat" configuration that will allow for
-// more complete overlayfs support.
+// OnDiskFormat represents the on-disk file format that is used when extracting
+// and assumed when repacking a rootfs.
+//
+// [DirRootfs] is the default format used by umoci, and is designed to be used
+// to extract a filesystem into a single directory on a regular unix
+// filesystem. In order to generate a new diff layer, it is necessary to use
+// mtree manifests to track changes.
+//
+// [OverlayfsRootfs] is an alternative format that is intended to be used with
+// overlayfs to avoid the need for mtree manifests. This means that layers are
+// intended to be extracted into separate directories and merged together with
+// overlayfs, which also means that OCI whiteouts are converted to and from
+// overlayfs's format.
+//
+// NOTE: At the moment [OverlayfsRootfs] cannot be used with the command-line
+// version of umoci nor the top-level umoci helpers, and most of the umoci API
+// still includes dependencies on mtree manifests (but you can pass a nil
+// manifest if using OverlayfsRootfs).
+type OnDiskFormat interface {
+	// This interface is used to combine both the type of rootfs as well as
+	// format-specific options inside the struct. As we use reflection, we
+	// cannot allow any external implementations of this interface.
+	onDiskFormatInternal()
 
-// WhiteoutMode indicates how this TarExtractor will create whiteouts on the
-// filesystem when it encounters them.
-type WhiteoutMode int
+	// Map returns the format-agnostic information about userns mapping.
+	Map() MapOptions
+}
 
-const (
-	// OCIStandardWhiteout does the standard OCI thing: a file named
-	// .wh.foo indicates you should rm -rf foo.
-	OCIStandardWhiteout WhiteoutMode = iota
+// DirRootfs is the default [OnDiskFormat] used by umoci, and is designed to be
+// used to extract a filesystem into a single directory on a regular unix
+// filesystem. In order to generate a new diff layer, it is necessary to use
+// mtree manifests to track changes.
+type DirRootfs struct {
+	// MapOptions represent the userns mappings that should be applied ot this
+	// rootfs.
+	MapOptions MapOptions
+}
 
-	// OverlayFSWhiteout generates a rootfs suitable for use in overlayfs,
-	// so it follows the overlayfs whiteout protocol:
-	//     .wh.foo => mknod c 0 0 foo
-	OverlayFSWhiteout
-)
+func (DirRootfs) onDiskFormatInternal() {}
+
+// Map returns the format-agnostic information about userns mapping.
+func (fs DirRootfs) Map() MapOptions { return fs.MapOptions }
+
+var _ OnDiskFormat = DirRootfs{}
+
+// OverlayfsRootfs is an alternative [OnDiskFormat] to the default [DirRootfs]
+// format that is intended to be used with overlayfs to avoid the need for
+// mtree manifests. This means that layers are intended to be extracted into
+// separate directories and merged together with overlayfs, which also means
+// that OCI whiteouts are converted to and from overlayfs's format.
+//
+// NOTE: At the moment [OverlayfsRootfs] cannot be used with the command-line
+// version of umoci nor the top-level umoci helpers, and most of the umoci API
+// still includes dependencies on mtree manifests (but you can pass a nil
+// manifest if using OverlayfsRootfs).
+type OverlayfsRootfs struct {
+	// MapOptions represent the userns mappings that should be applied ot this
+	// rootfs.
+	MapOptions MapOptions
+}
+
+func (OverlayfsRootfs) onDiskFormatInternal() {}
+
+// Map returns the format-agnostic information about userns mapping.
+func (fs OverlayfsRootfs) Map() MapOptions { return fs.MapOptions }
+
+var _ OnDiskFormat = OverlayfsRootfs{}
+
+// MapOptions specifies the UID and GID mappings used when unpacking and
+// repacking images, and whether the mapping is being done as a rootless user.
+type MapOptions struct {
+	// UIDMappings and GIDMappings are the UID and GID mappings to apply when
+	// packing and unpacking image rootfs layers.
+	UIDMappings []rspec.LinuxIDMapping `json:"uid_mappings"`
+	GIDMappings []rspec.LinuxIDMapping `json:"gid_mappings"`
+
+	// Rootless specifies whether any to error out if chown fails.
+	Rootless bool `json:"rootless"`
+}
 
 // UnpackOptions describes the behavior of the various unpack operations.
 type UnpackOptions struct {
-	// MapOptions are the UID and GID mappings used when unpacking an image
-	MapOptions MapOptions
+	// OnDiskFormat is what extraction format is used when writing to the
+	// filesystem. [OverlayfsRootfs] will cause whiteouts to be represented as
+	// whiteout inodes in the overlayfs format.
+	OnDiskFormat OnDiskFormat
 
 	// KeepDirlinks is essentially the same as rsync's --keep-dirlinks option.
 	// If, on extraction, a directory would be created where a symlink to a
@@ -56,20 +120,60 @@ type UnpackOptions struct {
 	// unpacked.
 	AfterLayerUnpack AfterLayerUnpackCallback
 
-	// StartFrom is the descriptor in the manifest to start from
+	// StartFrom is the descriptor in the manifest to start unpacking from.
 	StartFrom ispec.Descriptor
+}
 
-	// WhiteoutMode is the type of whiteout to write to the filesystem.
-	WhiteoutMode WhiteoutMode
+// fill replaces nil values in UnpackOptions with the correct default values.
+// If opt itself is nil then a new UnpackOptions struct is allocated and
+// returned.
+func (opt *UnpackOptions) fill() *UnpackOptions {
+	if opt == nil {
+		opt = &UnpackOptions{}
+	}
+	if opt.OnDiskFormat == nil {
+		opt.OnDiskFormat = DirRootfs{}
+	}
+	return opt
+}
+
+// MapOptions is shorthand for opt.OnDiskFormat.MapOptions(), except if
+// OnDiskFormat is nil then it will return the default MapOptions.
+func (opt UnpackOptions) MapOptions() MapOptions {
+	var mapOpt MapOptions
+	if opt.OnDiskFormat != nil {
+		mapOpt = opt.OnDiskFormat.Map()
+	}
+	return mapOpt
 }
 
 // RepackOptions describes the behavior of the various GenerateLayer operations.
 type RepackOptions struct {
-	// MapOptions are the UID and GID mappings used when unpacking an image
-	MapOptions MapOptions
+	// OnDiskFormat is what on-disk format the rootfs we are generating a layer
+	// from uses. [OverlayfsRootfs] will cause overlayfs format whiteouts to be
+	// converted to OCI whiteouts in the layer.
+	OnDiskFormat OnDiskFormat
+}
 
-	// TranslateOverlayWhiteouts changes char devices of type 0,0 to
-	// .wh.foo style whiteouts when generating tarballs. Without this,
-	// whiteouts are untouched.
-	TranslateOverlayWhiteouts bool
+// fill replaces nil values in RepackOptions with the correct default values.
+// If opt itself is nil then a new RepackOptions struct is allocated and
+// returned.
+func (opt *RepackOptions) fill() *RepackOptions {
+	if opt == nil {
+		opt = &RepackOptions{}
+	}
+	if opt.OnDiskFormat == nil {
+		opt.OnDiskFormat = DirRootfs{}
+	}
+	return opt
+}
+
+// MapOptions is shorthand for opt.OnDiskFormat.MapOptions(), except if
+// OnDiskFormat is nil then it will return the default MapOptions.
+func (opt RepackOptions) MapOptions() MapOptions {
+	var mapOpt MapOptions
+	if opt.OnDiskFormat != nil {
+		mapOpt = opt.OnDiskFormat.Map()
+	}
+	return mapOpt
 }

--- a/oci/layer/types_test.go
+++ b/oci/layer/types_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package layer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnpackOptionsHelpers(t *testing.T) {
+	expected := &UnpackOptions{
+		OnDiskFormat: DirRootfs{},
+	}
+
+	t.Run("NilStruct", func(t *testing.T) {
+		nilOpt := (*UnpackOptions)(nil)
+		got := nilOpt.fill()
+
+		assert.Equal(t, expected, got, "nil UnpackOptions.fill should fill nil values")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after UnpackOptions.fill")
+		assert.Nil(t, nilOpt, "nil UnpackOptions.fill won't affect original value")
+	})
+
+	t.Run("ZeroStruct", func(t *testing.T) {
+		zeroOpt := &UnpackOptions{}
+		got := zeroOpt.fill()
+
+		assert.Equal(t, expected, got, "zero UnpackOptions.fill should fill nil values")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after UnpackOptions.fill")
+		assert.Equal(t, expected, zeroOpt, "zero UnpackOptions.fill should update original struct")
+
+		assert.Zero(t, UnpackOptions{}.MapOptions(), "MapOptions should return zero-value for nil OnDiskFormat")
+	})
+
+	t.Run("ExplicitDirRootfs", func(t *testing.T) {
+		onDiskFmt := DirRootfs{MapOptions: MapOptions{Rootless: true}}
+		dirOpt := &UnpackOptions{
+			OnDiskFormat: onDiskFmt,
+		}
+		got := dirOpt.fill()
+
+		assert.NotEqual(t, expected, got, "UnpackOptions.fill should not modify already-set OnDiskFormat")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after UnpackOptions.fill")
+		assert.Equal(t, onDiskFmt, got.OnDiskFormat, "UnpackOptions.fill should not modify already-set OnDiskFormat")
+		assert.Equal(t, onDiskFmt, dirOpt.OnDiskFormat, "UnpackOptions.fill should not modify already-set OnDiskFormat")
+
+		assert.Equal(t, onDiskFmt.MapOptions, dirOpt.MapOptions(), "MapOptions should match actual MapOptions")
+	})
+
+	t.Run("OverlayfsRootfs", func(t *testing.T) {
+		onDiskFmt := DirRootfs{MapOptions: MapOptions{Rootless: true}}
+		overlayOpt := &UnpackOptions{
+			OnDiskFormat: onDiskFmt,
+		}
+		got := overlayOpt.fill()
+
+		assert.NotEqual(t, expected, got, "UnpackOptions.fill should not modify already-set OnDiskFormat")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after UnpackOptions.fill")
+		assert.Equal(t, onDiskFmt, got.OnDiskFormat, "UnpackOptions.fill should not modify already-set OnDiskFormat")
+		assert.Equal(t, onDiskFmt, overlayOpt.OnDiskFormat, "UnpackOptions.fill should not modify already-set OnDiskFormat")
+
+		assert.Equal(t, onDiskFmt.MapOptions, overlayOpt.MapOptions(), "MapOptions should match actual MapOptions")
+	})
+}
+
+func TestRepackOptionsHelpers(t *testing.T) {
+	expected := &RepackOptions{
+		OnDiskFormat: DirRootfs{},
+	}
+
+	t.Run("NilStruct", func(t *testing.T) {
+		nilOpt := (*RepackOptions)(nil)
+		got := nilOpt.fill()
+
+		assert.Equal(t, expected, got, "nil RepackOptions.fill should fill nil values")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after RepackOptions.fill")
+		assert.Nil(t, nilOpt, "nil RepackOptions.fill won't affect original value")
+	})
+
+	t.Run("ZeroStruct", func(t *testing.T) {
+		zeroOpt := &RepackOptions{}
+		got := zeroOpt.fill()
+
+		assert.Equal(t, expected, got, "zero RepackOptions.fill should fill nil values")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after RepackOptions.fill")
+		assert.Equal(t, expected, zeroOpt, "zero RepackOptions.fill should update original struct")
+	})
+
+	t.Run("ExplicitDirRootfs", func(t *testing.T) {
+		onDiskFmt := DirRootfs{MapOptions: MapOptions{Rootless: true}}
+		dirOpt := &RepackOptions{
+			OnDiskFormat: onDiskFmt,
+		}
+		got := dirOpt.fill()
+
+		assert.NotEqual(t, expected, got, "RepackOptions.fill should not modify already-set OnDiskFormat")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after RepackOptions.fill")
+		assert.Equal(t, onDiskFmt, got.OnDiskFormat, "RepackOptions.fill should not modify already-set OnDiskFormat")
+		assert.Equal(t, onDiskFmt, dirOpt.OnDiskFormat, "RepackOptions.fill should not modify already-set OnDiskFormat")
+
+		assert.Equal(t, onDiskFmt.MapOptions, dirOpt.MapOptions(), "MapOptions should match actual MapOptions")
+	})
+
+	t.Run("OverlayfsRootfs", func(t *testing.T) {
+		onDiskFmt := DirRootfs{MapOptions: MapOptions{Rootless: true}}
+		overlayOpt := &RepackOptions{
+			OnDiskFormat: onDiskFmt,
+		}
+		got := overlayOpt.fill()
+
+		assert.NotEqual(t, expected, got, "RepackOptions.fill should not modify already-set OnDiskFormat")
+		assert.NotNil(t, got.OnDiskFormat, "OnDiskFormat must be non-nil after RepackOptions.fill")
+		assert.Equal(t, onDiskFmt, got.OnDiskFormat, "RepackOptions.fill should not modify already-set OnDiskFormat")
+		assert.Equal(t, onDiskFmt, overlayOpt.OnDiskFormat, "RepackOptions.fill should not modify already-set OnDiskFormat")
+
+		assert.Equal(t, onDiskFmt.MapOptions, overlayOpt.MapOptions(), "MapOptions should match actual MapOptions")
+	})
+}

--- a/oci/layer/utils.go
+++ b/oci/layer/utils.go
@@ -25,24 +25,11 @@ import (
 	"path/filepath"
 
 	"github.com/apex/log"
-	rspec "github.com/opencontainers/runtime-spec/specs-go"
 	rootlesscontainers "github.com/rootless-containers/proto/go-proto"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/opencontainers/umoci/pkg/idtools"
 )
-
-// MapOptions specifies the UID and GID mappings used when unpacking and
-// repacking images.
-type MapOptions struct {
-	// UIDMappings and GIDMappings are the UID and GID mappings to apply when
-	// packing and unpacking image rootfs layers.
-	UIDMappings []rspec.LinuxIDMapping `json:"uid_mappings"`
-	GIDMappings []rspec.LinuxIDMapping `json:"gid_mappings"`
-
-	// Rootless specifies whether any to error out if chown fails.
-	Rootless bool `json:"rootless"`
-}
 
 // mapHeader maps a tar.Header generated from the filesystem so that it
 // describes the inode as it would be observed by a container process. In

--- a/oci/layer/utils_unix.go
+++ b/oci/layer/utils_unix.go
@@ -38,7 +38,7 @@ const (
 
 // isOverlayWhiteout returns true if the given path is an overlayfs whiteout,
 // and what kind of whiteout it represents.
-func isOverlayWhiteout(path string, fsEval fseval.FsEval) (overlayWhiteoutType, bool, error) {
+func isOverlayWhiteout(onDiskFmt OverlayfsRootfs, path string, fsEval fseval.FsEval) (overlayWhiteoutType, bool, error) {
 	stat, err := fsEval.Lstatx(path)
 	if err != nil {
 		return "", false, err
@@ -52,7 +52,7 @@ func isOverlayWhiteout(path string, fsEval fseval.FsEval) (overlayWhiteoutType, 
 		}
 	case unix.S_IFDIR:
 		// opaque whiteouts
-		val, err := fsEval.Lgetxattr(path, "trusted.overlay.opaque")
+		val, err := fsEval.Lgetxattr(path, onDiskFmt.xattr("opaque"))
 		if err != nil {
 			// If we are missing privileges to read the xattr (ENODATA) or the
 			// filesystem doesn't support xattrs (EOPNOTSUPP) we ignore the
@@ -85,7 +85,7 @@ func isOverlayWhiteout(path string, fsEval fseval.FsEval) (overlayWhiteoutType, 
 				}
 				names = []string{}
 			}
-			if slices.Contains(names, "trusted.overlay.whiteout") {
+			if slices.Contains(names, onDiskFmt.xattr("whiteout")) {
 				return overlayWhiteoutPlain, true, nil
 			}
 		}

--- a/oci/layer/xattr_linux_test.go
+++ b/oci/layer/xattr_linux_test.go
@@ -86,8 +86,6 @@ func testGenerateLayersForRoundTrip(t *testing.T, dir string, woType WhiteoutMod
 }
 
 func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
-	dir := t.TempDir()
-
 	testNeedsMknod(t)
 	testNeedsTrustedOverlayXattrs(t)
 
@@ -168,6 +166,8 @@ func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
 	} {
 		test := test // copy iterator
 		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+
 			unpackOptions := UnpackOptions{
 				MapOptions: MapOptions{
 					Rootless: os.Geteuid() != 0,
@@ -236,8 +236,6 @@ func TestUnpackGenerateRoundTrip_MockedSELinux(t *testing.T) {
 	require.Equalf(t, forbiddenXattrFilter{}, filter, "getXattrFilter(%q) should return the forbidden filter", forbiddenTestXattr)
 	require.Truef(t, filter.MaskedOnDisk(OCIStandardWhiteout, forbiddenTestXattr), "getXattrFilter(%q).MaskedOnDisk should be true", forbiddenTestXattr)
 
-	dir := t.TempDir()
-
 	dentries := []struct {
 		tarDentry
 		autoXattrs map[string]string
@@ -281,6 +279,8 @@ func TestUnpackGenerateRoundTrip_MockedSELinux(t *testing.T) {
 	} {
 		test := test // copy iterator
 		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+
 			unpackOptions := UnpackOptions{
 				MapOptions: MapOptions{
 					Rootless: os.Geteuid() != 0,

--- a/oci/layer/xattr_linux_test.go
+++ b/oci/layer/xattr_linux_test.go
@@ -49,7 +49,7 @@ func getAllXattrs(t *testing.T, path string) map[string]string {
 	return xattrs
 }
 
-func testGenerateLayersForRoundTrip(t *testing.T, dir string, woType WhiteoutMode, wantDentries []tarDentry) {
+func testGenerateLayersForRoundTrip(t *testing.T, dir string, onDiskFmt OnDiskFormat, wantDentries []tarDentry) {
 	t.Run("ToGenerateLayer", func(t *testing.T) {
 		// something reasonable
 		mtreeKeywords := []mtree.Keyword{
@@ -63,7 +63,7 @@ func testGenerateLayersForRoundTrip(t *testing.T, dir string, woType WhiteoutMod
 		require.NoError(t, err, "mtree check")
 
 		reader, err := GenerateLayer(dir, deltas, &RepackOptions{
-			TranslateOverlayWhiteouts: woType == OverlayFSWhiteout,
+			OnDiskFormat: onDiskFmt,
 		})
 		require.NoError(t, err, "generate layer")
 		defer reader.Close() //nolint:errcheck
@@ -75,7 +75,7 @@ func testGenerateLayersForRoundTrip(t *testing.T, dir string, woType WhiteoutMod
 
 	t.Run("ToGenerateInsertLayer", func(t *testing.T) {
 		reader := GenerateInsertLayer(dir, ".", false, &RepackOptions{
-			TranslateOverlayWhiteouts: woType == OverlayFSWhiteout,
+			OnDiskFormat: onDiskFmt,
 		})
 		defer reader.Close() //nolint:errcheck
 
@@ -85,7 +85,7 @@ func testGenerateLayersForRoundTrip(t *testing.T, dir string, woType WhiteoutMod
 	})
 }
 
-func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
+func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayfsRootfs(t *testing.T) {
 	testNeedsMknod(t)
 	testNeedsTrustedOverlayXattrs(t)
 
@@ -158,24 +158,30 @@ func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name   string
-		woType WhiteoutMode
+		name      string
+		onDiskFmt OnDiskFormat
 	}{
-		{"OverlayFSWhiteout", OverlayFSWhiteout},
-		{"OCIStandardWhiteout", OCIStandardWhiteout},
+		{"DirRootfs", DirRootfs{}},
+		{"OverlayfsRootfs", OverlayfsRootfs{}},
 	} {
 		test := test // copy iterator
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			unpackOptions := UnpackOptions{
-				MapOptions: MapOptions{
-					Rootless: os.Geteuid() != 0,
-				},
-				WhiteoutMode: test.woType,
+			switch onDiskFmt := test.onDiskFmt.(type) {
+			case DirRootfs:
+				onDiskFmt.MapOptions.Rootless = os.Geteuid() != 0
+				test.onDiskFmt = onDiskFmt
+			case OverlayfsRootfs:
+				onDiskFmt.MapOptions.Rootless = os.Geteuid() != 0
+				test.onDiskFmt = onDiskFmt
 			}
 
-			te := NewTarExtractor(unpackOptions)
+			unpackOptions := UnpackOptions{
+				OnDiskFormat: test.onDiskFmt,
+			}
+
+			te := NewTarExtractor(&unpackOptions)
 
 			for _, de := range dentries {
 				hdr, rdr := tarFromDentry(de.tarDentry)
@@ -189,10 +195,10 @@ func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
 
 				xattrs := getAllXattrs(t, fullPath)
 
-				switch test.woType {
-				case OverlayFSWhiteout:
-					// With extraction using OverlayFSWhiteout we expect to get
-					// the remapped xattrs.
+				switch test.onDiskFmt.(type) {
+				case OverlayfsRootfs:
+					// With extraction on OverlayfsRootfs we expect to get the
+					// remapped xattrs.
 					assert.Equalf(t, de.remapXattrs, xattrs, "UnpackEntry(%q): expected to see %#v remapped properly", path, de.xattrs)
 
 					// And so none of the inodes should be actual whiteouts.
@@ -200,10 +206,9 @@ func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
 					require.NoErrorf(t, err, "isOverlayWhiteout(%q)", path)
 					assert.Falsef(t, isWo, "isOverlayWhiteout(%q): regular entries with overlayfs xattrs should not end up being unpacked with overlayfs whiteout xattrs", path)
 
-				case OCIStandardWhiteout:
-					// For standard OCI extraction, trusted.overlay.* is not
-					// treated as a special xattr and so should not be
-					// remapped.
+				case DirRootfs:
+					// For DirRootfs, trusted.overlay.* is not treated as a
+					// special xattr and so should not be remapped.
 					xattrs := getAllXattrs(t, fullPath)
 					assert.Equalf(t, de.xattrs, xattrs, "UnpackEntry(%q): expected to see %#v not be remapped", path, de.xattrs)
 					assert.NotEqualf(t, de.remapXattrs, xattrs, "UnpackEntry(%q): expected to see %#v not be remapped", path, de.xattrs)
@@ -216,7 +221,7 @@ func TestUnpackGenerateRoundTrip_ComplexXattr_OverlayFS(t *testing.T) {
 			for _, dentry := range dentries {
 				wantDentries = append(wantDentries, dentry.tarDentry)
 			}
-			testGenerateLayersForRoundTrip(t, dir, unpackOptions.WhiteoutMode, wantDentries)
+			testGenerateLayersForRoundTrip(t, dir, unpackOptions.OnDiskFormat, wantDentries)
 		})
 	}
 }
@@ -234,7 +239,7 @@ func TestUnpackGenerateRoundTrip_MockedSELinux(t *testing.T) {
 	filter, isSpecial := getXattrFilter(forbiddenTestXattr)
 	require.Truef(t, isSpecial, "getXattrFilter(%q) should return a filter", forbiddenTestXattr)
 	require.Equalf(t, forbiddenXattrFilter{}, filter, "getXattrFilter(%q) should return the forbidden filter", forbiddenTestXattr)
-	require.Truef(t, filter.MaskedOnDisk(OCIStandardWhiteout, forbiddenTestXattr), "getXattrFilter(%q).MaskedOnDisk should be true", forbiddenTestXattr)
+	require.Truef(t, filter.MaskedOnDisk(DirRootfs{}, forbiddenTestXattr), "getXattrFilter(%q).MaskedOnDisk should be true", forbiddenTestXattr)
 
 	dentries := []struct {
 		tarDentry
@@ -271,24 +276,30 @@ func TestUnpackGenerateRoundTrip_MockedSELinux(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name   string
-		woType WhiteoutMode
+		name      string
+		onDiskFmt OnDiskFormat
 	}{
-		{"OverlayFSWhiteout", OverlayFSWhiteout},
-		{"OCIStandardWhiteout", OCIStandardWhiteout},
+		{"DirRootfs", DirRootfs{}},
+		{"OverlayfsRootfs", OverlayfsRootfs{}},
 	} {
 		test := test // copy iterator
 		t.Run(test.name, func(t *testing.T) {
 			dir := t.TempDir()
 
-			unpackOptions := UnpackOptions{
-				MapOptions: MapOptions{
-					Rootless: os.Geteuid() != 0,
-				},
-				WhiteoutMode: test.woType,
+			switch onDiskFmt := test.onDiskFmt.(type) {
+			case DirRootfs:
+				onDiskFmt.MapOptions.Rootless = os.Geteuid() != 0
+				test.onDiskFmt = onDiskFmt
+			case OverlayfsRootfs:
+				onDiskFmt.MapOptions.Rootless = os.Geteuid() != 0
+				test.onDiskFmt = onDiskFmt
 			}
 
-			te := NewTarExtractor(unpackOptions)
+			unpackOptions := UnpackOptions{
+				OnDiskFormat: test.onDiskFmt,
+			}
+
+			te := NewTarExtractor(&unpackOptions)
 
 			for _, de := range dentries {
 				hdr, rdr := tarFromDentry(de.tarDentry)
@@ -333,7 +344,7 @@ func TestUnpackGenerateRoundTrip_MockedSELinux(t *testing.T) {
 			for _, dentry := range dentries {
 				wantDentries = append(wantDentries, dentry.tarDentry)
 			}
-			testGenerateLayersForRoundTrip(t, dir, unpackOptions.WhiteoutMode, wantDentries)
+			testGenerateLayersForRoundTrip(t, dir, unpackOptions.OnDiskFormat, wantDentries)
 		})
 	}
 }

--- a/oci/layer/xattr_test.go
+++ b/oci/layer/xattr_test.go
@@ -78,21 +78,19 @@ func TestGetXattrFilter(t *testing.T) {
 	}
 }
 
-func ptr[T any](t T) *T { return &t }
-
 func TestOverlayXattrFilter(t *testing.T) {
 	for _, test := range []struct {
 		name          string
 		xattr         string
 		onDiskFmt     OnDiskFormat
-		toDisk, toTar *string
+		toDisk, toTar string
 	}{
-		{"NormalXattr", "trusted.example.xattr", OverlayfsRootfs{}, ptr("trusted.example.xattr"), ptr("trusted.example.xattr")},
-		{"TrustedOverlayXattr", "trusted.overlay.foo", OverlayfsRootfs{}, ptr("trusted.overlay.overlay.foo"), nil},
-		{"TrustedOverlayXattr-Escaped", "trusted.overlay.overlay.foo", OverlayfsRootfs{}, ptr("trusted.overlay.overlay.overlay.foo"), ptr("trusted.overlay.foo")},
+		{"NormalXattr", "trusted.example.xattr", OverlayfsRootfs{}, "trusted.example.xattr", "trusted.example.xattr"},
+		{"TrustedOverlayXattr", "trusted.overlay.foo", OverlayfsRootfs{}, "trusted.overlay.overlay.foo", ""},
+		{"TrustedOverlayXattr-Escaped", "trusted.overlay.overlay.foo", OverlayfsRootfs{}, "trusted.overlay.overlay.overlay.foo", "trusted.overlay.foo"},
 		// TODO: Implement support for these.
-		{"UserOverlayXattr", "user.overlay.foo", OverlayfsRootfs{}, ptr("user.overlay.foo"), ptr("user.overlay.foo")},
-		{"UserOverlayXattr-Escaped", "user.overlay.overlay.foo", OverlayfsRootfs{}, ptr("user.overlay.overlay.foo"), ptr("user.overlay.overlay.foo")},
+		{"UserOverlayXattr", "user.overlay.foo", OverlayfsRootfs{}, "user.overlay.foo", "user.overlay.foo"},
+		{"UserOverlayXattr-Escaped", "user.overlay.overlay.foo", OverlayfsRootfs{}, "user.overlay.overlay.foo", "user.overlay.overlay.foo"},
 	} {
 		test := test // copy iterator
 		t.Run(test.name, func(t *testing.T) {
@@ -103,7 +101,7 @@ func TestOverlayXattrFilter(t *testing.T) {
 				filter = overlayXattrFilter{}
 			}
 
-			expectMasked := test.toTar == nil
+			expectMasked := test.toTar == ""
 			gotMasked := filter.MaskedOnDisk(test.onDiskFmt, test.xattr)
 			assert.Equal(t, expectMasked, gotMasked, "MaskedOnDisk(%#v, %q)", test.onDiskFmt, test.xattr)
 

--- a/repack.go
+++ b/repack.go
@@ -115,7 +115,9 @@ func Repack(engineExt casext.Engine, tagName, bundlePath string,
 		}
 	} else {
 		reader, err := layer.GenerateLayer(fullRootfsPath, diffs, &layer.RepackOptions{
-			MapOptions: meta.MapOptions,
+			OnDiskFormat: layer.DirRootfs{
+				MapOptions: meta.MapOptions,
+			},
 		})
 		if err != nil {
 			return fmt.Errorf("generate diff layer: %w", err)

--- a/unpack.go
+++ b/unpack.go
@@ -37,7 +37,7 @@ import (
 func Unpack(engineExt casext.Engine, fromName, bundlePath string, unpackOptions layer.UnpackOptions) (Err error) {
 	meta := Meta{
 		Version:    MetaVersion,
-		MapOptions: unpackOptions.MapOptions,
+		MapOptions: unpackOptions.MapOptions(),
 	}
 
 	fromDescriptorPaths, err := engineExt.ResolveReference(context.Background(), fromName)

--- a/utils.go
+++ b/utils.go
@@ -97,7 +97,7 @@ type Meta struct {
 	// NOTE: This field has been deprecated, as the feature was completely
 	// broken. See <https://github.com/opencontainers/umoci/issues/574> for
 	// more details.
-	DeprecatedWhiteoutMode layer.WhiteoutMode `json:"whiteout_mode,omitempty"`
+	DeprecatedWhiteoutMode int `json:"whiteout_mode,omitempty"`
 }
 
 // WriteTo writes a JSON-serialised version of Meta to the given io.Writer.
@@ -141,8 +141,8 @@ func ReadBundleMeta(bundle string) (_ Meta, Err error) {
 	// NOTE: This field has been deprecated, as the feature was completely
 	// broken. See <https://github.com/opencontainers/umoci/issues/574> for
 	// more details.
-	if meta.DeprecatedWhiteoutMode != layer.OCIStandardWhiteout {
-		return meta, fmt.Errorf("decode metadata: deprecated (broken) whiteout_mode field set")
+	if meta.DeprecatedWhiteoutMode != 0 {
+		return meta, fmt.Errorf("decode metadata: deprecated (broken) whiteout_mode field set (%d)", meta.DeprecatedWhiteoutMode)
 	}
 	return meta, nil
 }


### PR DESCRIPTION
Since Linux 5.11, overlayfs supports using "user.overlay." as the xattr
namespace for special overlayfs xattrs (rather than the default
"trusted.overlay.") when mounted using the "userxattr" mount option.
This is a key part of unprivileged overlayfs mounting.

For the most part, supporting this is fairly straightforward now that
the on-disk format is represented with OverlayfsRootfs -- all hardcoded
references to "trusted.overlay." just need to take into account the
value of OverlayfsRootfs.UserXattr. Downstreams like stacker have had
out-of-tree patches to support operating on these xattrs for a long time
(since they use unprivileged overlayfs mounts whenever possible), so
supporting it in a more structured way should be very welcome.

One key thing to note is that (just like overlayfs) we only ever treat
one of "trusted.overlay." or "user.overlay." as special. The existing
tests also only needed miminal adjustments, and include tests to make
sure that we only ever touch the appropriate namespace.

This also finally allows us to run the overlayfs tests as an
unprivileged user.

Implements #576
Implements #584
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>