### PR TITLE
version: use go:embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Changed ###
+* We now use `go:embed` to fill the version information of `umoci --version`,
+  allowing for users to get a reasonable binary with `go install`. However, we
+  still recommend using our official binaries, using distribution binaries, or
+  building from source with `make`.
+
 ## [0.5.0] - 2025-05-21 ##
 
 > A wizard is never late, Frodo Baggins. Nor is he early; he arrives precisely

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO
 # Basic build flags.
 BUILD_FLAGS ?=
 BASE_FLAGS := ${BUILD_FLAGS} -tags "${BUILDTAGS}" -buildvcs=false
-BASE_LDFLAGS := -s -w -X ${PROJECT}.gitCommit=${COMMIT} -X ${PROJECT}.version=${VERSION}
+BASE_LDFLAGS := -s -w -X ${PROJECT}.gitCommit=${COMMIT}
 
 # Specific build flags for build type.
 ifeq ($(GOOS), linux)

--- a/README.md
+++ b/README.md
@@ -148,7 +148,14 @@ umoci is also available from several distributions' repositories:
 * [Arch Linux (AUR)](https://aur.archlinux.org/packages/umoci/)
 
 To build umoci from the [source code][source], a simple `make` should work on
-most machines, as should `make install`.
+most machines, as should `make install`. If you prefer to use `go install`, you
+can use
+
+```
+% go install github.com/opencontainers/umoci/cmd/umoci@latest
+```
+
+but we recommend using `make` instead.
 
 [releases]: https://github.com/opencontainers/umoci/releases
 [umoci-keyring]: /umoci.keyring

--- a/version.go
+++ b/version.go
@@ -19,29 +19,27 @@
 package umoci
 
 import (
-	"fmt"
+	_ "embed" // for go:embed
+	"strings"
 )
 
-// These are populated during "make" using -ldflags "-X ...".
-// TODO: Switch to embedding the version here so that FullVersion() makes sense
-//
-//	even when umoci is used as a library.
 var (
-	version   = "unknown"
-	gitCommit = ""
+	// version is the official release version.
+	//go:embed VERSION
+	version string
+
+	// Populated by "make".
+	gitCommit string
 )
 
 // FullVersion returns a fully-qualified version string if one is available.
-// NOTE: This function will return "unknown" if umoci is being used as a "go
-//
-//	get" dependency or binary.
 func FullVersion() string {
 	v := "unknown"
 	if version != "" {
-		v = version
+		v = strings.TrimSpace(version)
 	}
 	if gitCommit != "" {
-		v = fmt.Sprintf("%s~git%s", v, gitCommit)
+		v += "~git" + gitCommit
 	}
 	return v
 }


### PR DESCRIPTION
go:embed was added way back in Go 1.16, so we can easily move to it now,
and now we can be sure that "go install" installs will have the correct
version information.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>