### PR TITLE
oci: add SOURCE_DATE_EPOCH support for reproducible builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added ###
 * `umoci stat` now includes information about the manifest and configuration of
   the image, both in the regular and JSON-formatted outputs.
+* umoci now has [`SOURCE_DATE_EPOCH`][source-date-epoch] support, to attempt to
+  make it easier to create reproducible images. Our behaviour is modelled after
+  `tar --clamp-mtime`, meaning that `SOURCE_DATE_EPOCH` will only be used to
+  modify the timestamps of files **newer** than `SOURCE_DATE_EPOCH`.
+
+  As `umoci repack` works based on diffs, this also means that only files that
+  were modified (and will thus be usually be included in the new layer) will
+  have their timestamps rewritten.
+
+  `--history.created` will also now default to `SOURCE_DATE_EPOCH` (if set).
+
+  With this change, umoci should be fairly compliant with reproducible builds.
+  Please let us know if you find any other problematic areas in umoci (we are
+  investigating some other possible causes of instability such as Go map
+  iteration).
 
 ### Fixed ###
 * Some minor aspects of how `umoci stat` would filter special characters in
   history entries have been resolved.
+
+[source-date-epoch]: https://reproducible-builds.org/docs/source-date-epoch/
 
 ## [0.5.1] - 2025-09-05 ##
 

--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -293,9 +293,17 @@ func config(ctx *cli.Context) (Err error) {
 		}
 	}
 
+	sourceDateEpoch, err := parseSourceDateEpoch()
+	if err != nil {
+		return err
+	}
+
 	var history *ispec.History
 	if !ctx.Bool("no-history") {
 		created := time.Now()
+		if sourceDateEpoch != nil {
+			created = *sourceDateEpoch
+		}
 		history = &ispec.History{
 			Author:     g.Author(),
 			Comment:    "",
@@ -310,6 +318,7 @@ func config(ctx *cli.Context) (Err error) {
 		if ctx.IsSet("history.comment") {
 			history.Comment = ctx.String("history.comment")
 		}
+		// If set, takes precedence over SOURCE_DATE_EPOCH.
 		if ctx.IsSet("history.created") {
 			created, err := time.Parse(igen.ISO8601, ctx.String("history.created"))
 			if err != nil {

--- a/cmd/umoci/new.go
+++ b/cmd/umoci/new.go
@@ -60,6 +60,11 @@ func newImage(ctx *cli.Context) (Err error) {
 	imagePath := mustFetchMeta[string](ctx, "--image-path")
 	tagName := mustFetchMeta[string](ctx, "--image-tag")
 
+	sourceDateEpoch, err := parseSourceDateEpoch()
+	if err != nil {
+		return err
+	}
+
 	// Get a reference to the CAS.
 	engine, err := dir.Open(imagePath)
 	if err != nil {
@@ -68,5 +73,5 @@ func newImage(ctx *cli.Context) (Err error) {
 	engineExt := casext.NewEngine(engine)
 	defer funchelpers.VerifyClose(&Err, engine)
 
-	return umoci.NewImage(engineExt, tagName)
+	return umoci.NewImage(engineExt, tagName, sourceDateEpoch)
 }

--- a/cmd/umoci/raw-add-layer.go
+++ b/cmd/umoci/raw-add-layer.go
@@ -134,9 +134,17 @@ func rawAddLayer(ctx *cli.Context) (Err error) {
 		return fmt.Errorf("get image metadata: %w", err)
 	}
 
+	sourceDateEpoch, err := parseSourceDateEpoch()
+	if err != nil {
+		return err
+	}
+
 	var history *ispec.History
 	if !ctx.Bool("no-history") {
 		created := time.Now()
+		if sourceDateEpoch != nil {
+			created = *sourceDateEpoch
+		}
 		history = &ispec.History{
 			Author:     imageMeta.Author,
 			Comment:    "",

--- a/cmd/umoci/utils.go
+++ b/cmd/umoci/utils.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// parseSourceDateEpoch parses the SOURCE_DATE_EPOCH environment variable
+// and returns the corresponding time.Time or nil if not set.
+func parseSourceDateEpoch() (*time.Time, error) {
+	val := os.Getenv("SOURCE_DATE_EPOCH")
+	if val == "" {
+		return nil, nil //nolint:nilnil // *time.Time is preferred
+	}
+	timestamp, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse SOURCE_DATE_EPOCH=%q: %w", val, err)
+	}
+	epoch := time.Unix(timestamp, 0).UTC()
+	return &epoch, nil
+}

--- a/cmd/umoci/utils_test.go
+++ b/cmd/umoci/utils_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSourceDateEpoch(t *testing.T) {
+	t.Run("EmptyEnvironmentVariable", func(t *testing.T) {
+		require.NoError(t, os.Unsetenv("SOURCE_DATE_EPOCH"))
+
+		result, err := parseSourceDateEpoch()
+
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("ValidTimestamp", func(t *testing.T) {
+		t.Setenv("SOURCE_DATE_EPOCH", "1234567890")
+
+		result, err := parseSourceDateEpoch()
+
+		require.NoError(t, err)
+		assert.False(t, result.IsZero())
+		assert.Equal(t, int64(1234567890), result.Unix())
+		assert.Equal(t, time.UTC, result.Location())
+	})
+
+	t.Run("InvalidFormat", func(t *testing.T) {
+		t.Setenv("SOURCE_DATE_EPOCH", "not-a-number")
+
+		result, err := parseSourceDateEpoch()
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "parse SOURCE_DATE_EPOCH=")
+	})
+}

--- a/new.go
+++ b/new.go
@@ -33,7 +33,7 @@ import (
 )
 
 // NewImage creates a new empty image (tag) in the existing layout.
-func NewImage(engineExt casext.Engine, tagName string) error {
+func NewImage(engineExt casext.Engine, tagName string, sourceDateEpoch *time.Time) error {
 	// Create a new manifest.
 	log.WithFields(log.Fields{
 		"tag": tagName,
@@ -42,6 +42,9 @@ func NewImage(engineExt casext.Engine, tagName string) error {
 	// Create a new image config.
 	g := igen.New()
 	createTime := time.Now()
+	if sourceDateEpoch != nil {
+		createTime = *sourceDateEpoch
+	}
 
 	// Set all of the defaults we need.
 	g.SetCreated(createTime)

--- a/oci/layer/types.go
+++ b/oci/layer/types.go
@@ -20,6 +20,7 @@ package layer
 
 import (
 	"strings"
+	"time"
 
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	rspec "github.com/opencontainers/runtime-spec/specs-go"
@@ -176,6 +177,11 @@ type RepackOptions struct {
 	// from uses. [OverlayfsRootfs] will cause overlayfs format whiteouts to be
 	// converted to OCI whiteouts in the layer.
 	OnDiskFormat OnDiskFormat
+
+	// SourceDateEpoch, if set, specifies the timestamp to use for clamping
+	// layer content timestamps. If not set, layer content timestamps are
+	// preserved as-is.
+	SourceDateEpoch *time.Time
 }
 
 // fill replaces nil values in RepackOptions with the correct default values.

--- a/repack.go
+++ b/repack.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/apex/log"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -48,6 +49,7 @@ func Repack(engineExt casext.Engine, tagName, bundlePath string,
 	refreshBundle bool,
 	mutator *mutate.Mutator,
 	layerCompressor mutate.Compressor, //nolint:staticcheck // SA1019: this interface is defined by us and we keep it for compatibility
+	sourceDateEpoch *time.Time,
 ) (Err error) {
 	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), ":", "_", 1)
 	mtreePath := filepath.Join(bundlePath, mtreeName+".mtree")
@@ -118,6 +120,7 @@ func Repack(engineExt casext.Engine, tagName, bundlePath string,
 			OnDiskFormat: layer.DirRootfs{
 				MapOptions: meta.MapOptions,
 			},
+			SourceDateEpoch: sourceDateEpoch,
 		})
 		if err != nil {
 			return fmt.Errorf("generate diff layer: %w", err)

--- a/test/source_date_epoch.bats
+++ b/test/source_date_epoch.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats -t
+# SPDX-License-Identifier: Apache-2.0
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2016-2025 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+function setup() {
+	setup_tmpdirs
+	setup_image
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+}
+
+@test "umoci new [w/SOURCE_DATE_EPOCH]" {
+	IMAGE="$(setup_tmpdir)/image" TAG="test-new"
+
+	umoci init --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+
+	target_epoch="$(date -ud 'now - 6 months' +%s)"
+	target_date="$(date -ud "@$target_epoch" +%FT%TZ)" # --iso-8601 doesn't use "Z"
+
+	# Create blank image.
+	export SOURCE_DATE_EPOCH="$target_epoch"
+	umoci new --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+	unset SOURCE_DATE_EPOCH
+
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	# Make sure the default config created time uses SOURCE_DATE_EPOCH too.
+	config_created_time="$(jq -SMr '.config.blob.created' <<<"$output")"
+	[[ "$config_created_time" == "$target_date" ]]
+}
+
+@test "umoci config [SOURCE_DATE_EPOCH]" {
+	IMAGE="$(setup_tmpdir)/image" TAG="test-new"
+
+	umoci init --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+
+	target_epoch="$(date -ud 'now - 6 months' +%s)"
+	target_date="$(date -ud "@$target_epoch" +%FT%TZ)" # --iso-8601 doesn't use "Z"
+
+	export SOURCE_DATE_EPOCH="$target_epoch"
+	umoci new --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+	umoci config --config.user="foo:bar" --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+	unset SOURCE_DATE_EPOCH
+
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	# Make sure the default config created time uses SOURCE_DATE_EPOCH too.
+	config_created_time="$(jq -SMr '.config.blob.created' <<<"$output")"
+	[[ "$config_created_time" == "$target_date" ]]
+	# Make sure that the history entry uses SOURCE_DATE_EPOCH too.
+	history_created_time="$(jq -SMr '.history[-1].created' <<<"$output")"
+	[[ "$history_created_time" == "$target_date" ]]
+}
+
+@test "umoci config --created --history.created [SOURCE_DATE_EPOCH]" {
+	IMAGE="$(setup_tmpdir)/image" TAG="test-new"
+
+	umoci init --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+
+	dummy_epoch="$(date -ud 'now - 6 months' +%s)"
+	dummy_date="$(date -ud "@$dummy_epoch" +%FT%TZ)" # --iso-8601 doesn't use "Z"
+
+	target_config_date="1997-03-25T13:40:00+01:00"
+	target_history_date="1997-03-25T13:40:00+01:00"
+
+	export SOURCE_DATE_EPOCH="$dummy_epoch"
+	umoci new --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+	umoci config --image "${IMAGE}:${TAG}" \
+		--config.user="foo:bar" \
+		--created="$target_config_date" \
+		--history.created="$target_history_date"
+	[ "$status" -eq 0 ]
+	unset SOURCE_DATE_EPOCH
+
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	# If --created or --history.created are explicitly set, SOURCE_DATE_EPOCH
+	# is ignored.
+	config_created_time="$(jq -SMr '.config.blob.created' <<<"$output")"
+	[[ "$config_created_time" == "$target_config_date" ]]
+	history_created_time="$(jq -SMr '.history[-1].created' <<<"$output")"
+	[[ "$history_created_time" == "$target_history_date" ]]
+}
+
+@test "umoci new [w/o SOURCE_DATE_EPOCH]" {
+	IMAGE="$(setup_tmpdir)/image" TAG="test-new"
+
+	unset SOURCE_DATE_EPOCH
+
+	umoci init --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+
+	before_epoch="$(date -u +%s)"
+
+	umoci new --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+
+	after_epoch="$(date -u +%s)"
+
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	# Make sure that in the absense of SOURCE_DATE_EPOCH you get a reasonable
+	# time value (i.e., the current time).
+	config_created_time="$(jq -SMr '.config.blob.created' <<<"$output")"
+	config_created_epoch="$(date -u -d "$config_created_time" +%s)"
+	[ "$config_created_epoch" -ge "$before_epoch" ]
+	[ "$config_created_epoch" -le "$after_epoch" ]
+}
+
+@test "umoci repack [SOURCE_DATE_EPOCH]" {
+	# Unpack the image.
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	target_epoch="$(date -ud 'now - 20 years' +%s)"
+	target_date="$(date -ud "@$target_epoch" +%FT%TZ)" # --iso-8601 doesn't use "Z"
+
+	untouched_file_epoch="$(stat -c '%Y' "$ROOTFS/bin/sh")"
+
+	touch "$ROOTFS/etc/passwd"
+	touched_file_epoch="$(stat -c '%Y' "$ROOTFS/etc/passwd")"
+	echo "newfile" >"$ROOTFS/newfile"
+
+	echo "oldfile" >"$ROOTFS/oldfile"
+	touch -d "1997-03-25T13:40:00" "$ROOTFS/oldfile"
+	old_file_epoch="$(stat -c '%Y' "$ROOTFS/oldfile")"
+
+	# Make sure that the untouched file from the lower layer is newer than
+	# SOURCE_DATE_EPOCH (to make sure we aren't modifying the mtimes of
+	# untouched files).
+	[ "$untouched_file_epoch" -gt "$target_epoch" ]
+	[ "$touched_file_epoch" -gt "$target_epoch" ]
+	[ "$old_file_epoch" -lt "$target_epoch" ]
+
+	export SOURCE_DATE_EPOCH="$target_epoch"
+	umoci repack --image "${IMAGE}:${TAG}-new" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+	unset SOURCE_DATE_EPOCH
+
+	# Unpack it again (without SOURCE_DATE_EPOCH).
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}-new" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	# Files newer than SOURCE_DATE_EPOCH should be set to SOURCE_DATE_EPOCH.
+	[ "$(stat -c '%Y' "$ROOTFS/etc/passwd")" -eq "$target_epoch" ]
+	[ "$(stat -c '%Y' "$ROOTFS/newfile")" -eq "$target_epoch" ]
+
+	# Old files should remain the same.
+	[ "$(stat -c '%Y' "$ROOTFS/oldfile")" -eq "$old_file_epoch" ]
+
+	# Files from lower layer should also remain the same.
+	[ "$(stat -c '%Y' "$ROOTFS/bin/sh")" -eq "$untouched_file_epoch" ]
+
+	umoci stat --image "${IMAGE}:${TAG}-new" --json
+	[ "$status" -eq 0 ]
+	# Make sure that the history entry uses SOURCE_DATE_EPOCH too.
+	history_created_time="$(jq -SMr '.history[-1].created' <<<"$output")"
+	[[ "$history_created_time" == "$target_date" ]]
+}
+
+@test "umoci insert [SOURCE_DATE_EPOCH]" {
+	# Unpack the image.
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	target_epoch="$(date -ud 'now - 4 weeks' +%s)"
+	target_date="$(date -ud "@$target_epoch" +%FT%TZ)" # --iso-8601 doesn't use "Z"
+
+	insert_dir="$(setup_tmpdir)"
+	mkdir -p "$insert_dir/foo/bar/baz"
+	ln -s foo "$insert_dir/link"
+
+	new_file_date="$(date -ud 'now + 3 years' +%Y%m%dT%H:%M:%S)"
+	echo "newerfile" >"$insert_dir/newer"
+	touch -d "$new_file_date" "$insert_dir/newer"
+
+	old_file_date="$(date -ud 'now - 2 years' +%Y%m%dT%H:%M:%S)"
+	old_file_epoch="$(date -ud "$old_file_date" +%s)"
+	echo "olderfile" >"$insert_dir/older"
+	touch -d "$old_file_date" "$insert_dir/older"
+
+	export SOURCE_DATE_EPOCH="$target_epoch"
+	umoci insert --image "${IMAGE}:${TAG}" "$insert_dir" /dummy
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+	unset SOURCE_DATE_EPOCH
+
+	# Unpack it (without SOURCE_DATE_EPOCH).
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	# Files newer than SOURCE_DATE_EPOCH should be set to SOURCE_DATE_EPOCH.
+	[ "$(stat -c '%Y' "$ROOTFS/dummy")" -eq "$target_epoch" ]
+	[ "$(stat -c '%Y' "$ROOTFS/dummy/foo")" -eq "$target_epoch" ]
+	[ "$(stat -c '%Y' "$ROOTFS/dummy/foo/bar")" -eq "$target_epoch" ]
+	[ "$(stat -c '%Y' "$ROOTFS/dummy/foo/bar/baz")" -eq "$target_epoch" ]
+	[ "$(stat -c '%Y' "$ROOTFS/dummy/link")" -eq "$target_epoch" ]
+	[ "$(stat -c '%Y' "$ROOTFS/dummy/newer")" -eq "$target_epoch" ]
+
+	# Old files should remain the same.
+	[ "$(stat -c '%Y' "$ROOTFS/dummy/older")" -eq "$old_file_epoch" ]
+
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	# Make sure that the history entry uses SOURCE_DATE_EPOCH too.
+	history_created_time="$(jq -SMr '.history[-1].created' <<<"$output")"
+	[[ "$history_created_time" == "$target_date" ]]
+}


### PR DESCRIPTION
In order to make it easier for users to get reproducible builds out of
umoci without worrying about timestamp non-determinism, add support for
[SOURCE_DATE_EPOCH][1]. This affects most commands that involve adding
history entries or inserting layers.

For commands that just insert history entries or fill timestamp values,
SOURCE_DATE_EPOCH acts as the new default for those time.Time fields.
(But user-specified values still take precedence.)

For commands that insert layers, this patch implements "tar
--clamp-mtime" behavior (which is recommended by the spec), meaning that
only timestamps newer than SOURCE_DATE_EPOCH get modified and replaced
with SOURCE_DATE_EPOCH. Older timestamps are unaffected.

[1]: https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Danish Prakash <contact@danishpraka.sh>
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>
