### PR TITLE
hotfix: disable image validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,8 @@ jobs:
       GOCOVERDIR: umoci.coverdir
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - name: download ci image
         uses: actions/download-artifact@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
 [submodule ".site/themes/hugo-theme-learn"]
 	path = .site/themes/hugo-theme-learn
 	url = https://github.com/matcornic/hugo-theme-learn.git
+[submodule "hack/oci-validate/meta-scripts"]
+	path = hack/docker-meta-scripts
+	url = https://github.com/cyphar/docker-meta-scripts.git
+	branch = umoci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   allowing for users to get a reasonable binary with `go install`. However, we
   still recommend using our official binaries, using distribution binaries, or
   building from source with `make`.
+* Rather than using `oci-image-tool validate` for validating images in our
+  tests, we now make use of some hand-written smoke tests as well as the
+  `jq`-based validators maintained in [docker-library/meta-scripts][].
+
+  This is intended to act as a stop-gap until `umoci validate` is implemented
+  (and after that, we may choose to keep the `jq`-based validators as a
+  double-check that our own validators are working correctly).
+
+[docker-library/meta-scripts]: https://github.com/docker-library/meta-scripts
 
 ## [0.5.0] - 2025-05-21 ##
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Fixed ###
+* For images with an empty `index.json`, umoci will no longer incorrectly set
+  the `manifests` entry to `null` (which was technically a violation of the
+  specification, though such images cannot be pushed or interacted with outside
+  of umoci).
+
 ### Changed ###
 * We now use `go:embed` to fill the version information of `umoci --version`,
   allowing for users to get a reasonable binary with `go install`. However, we

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,22 +68,6 @@ RUN git clone -b v0.5.0 https://github.com/opencontainers/runtime-tools.git /tmp
 		go mod vendor; ) && \
 	make -C /tmp/oci-runtime-tools tool install && \
 	rm -rf /tmp/oci-runtime-tools
-# FIXME: oci-image-tool was basically broken for our needs after v0.3.0 (it
-#        cannot scan image layouts). The source is so old we need to manually
-#        build it (including doing "go mod init"). For the same reason as
-#        above, we need to force the usage of image-spec v1.0.0 because Go 1.22
-#        stopped converting from glide to go.mod.
-RUN git clone -b v0.3.0 https://github.com/opencontainers/image-tools.git /tmp/oci-image-tools && \
-	( cd /tmp/oci-image-tools && \
-		git ls-files --no-recurse-submodules -z | \
-			xargs -0 -I :: find :: -maxdepth 0 -type f -print0 | \
-			xargs -0 sed -Ei 's|github.com/Sirupsen/logrus|github.com/sirupsen/logrus|g' && \
-		go mod init github.com/opencontainers/image-tools && \
-		go get github.com/opencontainers/image-spec@v1.0.0 && \
-		go mod tidy && \
-		go mod vendor; ) && \
-	make -C /tmp/oci-image-tools all install && \
-	rm -rf /tmp/oci-image-tools
 
 ENV SOURCE_IMAGE=/opensuse SOURCE_TAG=latest
 ARG TEST_DOCKER_IMAGE=registry.opensuse.org/opensuse/leap:15.4

--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -487,6 +487,7 @@ func Create(path string) (Err error) {
 			SchemaVersion: 2, // FIXME: This is hardcoded at the moment.
 		},
 		MediaType: ispec.MediaTypeImageIndex,
+		Manifests: []ispec.Descriptor{},
 	}
 	if err := json.NewEncoder(indexFh).Encode(defaultIndex); err != nil {
 		return fmt.Errorf("encode index.json: %w", err)

--- a/oci/casext/refname.go
+++ b/oci/casext/refname.go
@@ -134,7 +134,7 @@ func (e Engine) UpdateReference(ctx context.Context, refname string, descriptor 
 	}
 
 	// TODO: Handle refname = "".
-	var newIndex []ispec.Descriptor
+	newIndex := make([]ispec.Descriptor, 0, len(index.Manifests)+1)
 	for _, descriptor := range index.Manifests {
 		if descriptor.Annotations[ispec.AnnotationRefName] != refname {
 			newIndex = append(newIndex, descriptor)
@@ -177,7 +177,7 @@ func (e Engine) DeleteReference(ctx context.Context, refname string) error {
 	}
 
 	// TODO: Handle refname = "".
-	var newIndex []ispec.Descriptor
+	newIndex := make([]ispec.Descriptor, 0, len(index.Manifests))
 	for _, descriptor := range index.Manifests {
 		if descriptor.Annotations[ispec.AnnotationRefName] != refname {
 			newIndex = append(newIndex, descriptor)
@@ -206,7 +206,7 @@ func (e Engine) ListReferences(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("get top-level index: %w", err)
 	}
 
-	var refs []string
+	refs := make([]string, 0, len(index.Manifests))
 	for _, descriptor := range index.Manifests {
 		ref, ok := descriptor.Annotations[ispec.AnnotationRefName]
 		if ok {

--- a/test/create.bats
+++ b/test/create.bats
@@ -151,14 +151,12 @@ function teardown() {
 	# Create a new image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$IMAGE"
+	image-verify "$IMAGE"
 
 	# Modify the config.
 	umoci config --image "${IMAGE}:${TAG}" --config.user "1234:1332"
 	[ "$status" -eq 0 ]
-	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$IMAGE"
+	image-verify "$IMAGE"
 
 	# Unpack the image.
 	new_bundle_rootfs
@@ -191,9 +189,7 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	# There should be no non-empty_layers.
 	[[ "$(echo "$output" | jq -SM '[.history[] | .empty_layer == null] | any')" == "false" ]]
-
-	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$IMAGE"
+	image-verify "$IMAGE"
 }
 
 # Given the bad experiences we've had with Go compiler changes resulting in
@@ -225,8 +221,7 @@ function teardown() {
 	# Create a new image with another tag.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$IMAGE"
+	image-verify "$IMAGE"
 
 	# Unpack the image.
 	new_bundle_rootfs

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -130,7 +130,10 @@ function image-verify() {
 	fi
 
 	# oci-spec validation
-	oci-image-tool validate --type "imageLayout" "$ocidir"
+	# FIXME: oci-image-tool broke due to image-spec repo changes, and so we
+	#        have to skip this for now. The eventual plan is to move the
+	#        validation to umoci itself.
+	#oci-image-tool validate --type "imageLayout" "$ocidir"
 	return $?
 }
 

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -27,6 +27,9 @@ UMOCI="${UMOCI:-${INTEGRATION_ROOT}/../umoci}"
 RUNC="/usr/bin/runc"
 GOMTREE="/usr/bin/gomtree"
 
+# Used as a poor man's oci-image-tool validate.
+DOCKER_METASCRIPT_DIR="${INTEGRATION_ROOT}/../hack/docker-meta-scripts"
+
 # The source OCI image path, which we will make a copy of for each test.
 SOURCE_IMAGE="${SOURCE_IMAGE:-/image}"
 SOURCE_TAG="${SOURCE_TAG:-latest}"
@@ -128,6 +131,11 @@ function image-verify() {
 		echo "$allowners"
 		fail "image $ocidir contains subpaths with incorrect owners"
 	fi
+
+	# Use the Docker meta-scripts (which use jq internally) to do some basic
+	# validation of our image.
+	BASHBREW_META_SCRIPTS="$DOCKER_METASCRIPT_DIR" \
+		"$DOCKER_METASCRIPT_DIR/helpers/oci-validate.sh" "$ocidir"
 
 	# oci-spec validation
 	# FIXME: oci-image-tool broke due to image-spec repo changes, and so we

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -420,7 +420,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add layer to the image.
 	umoci insert --image "${IMAGE}:${TAG}" --compress=zstd "${INSERTDIR}/etc" /etc
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -476,7 +476,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add zstd layer to the image.
 	umoci insert --image "${IMAGE}:${TAG}" --compress=zstd "${INSERTDIR}/etc" /etc
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -497,7 +497,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add another zstd layer to the image, by making use of the auto selection.
 	umoci insert --image "${IMAGE}:${TAG}" --compress=auto "${INSERTDIR}/etc" /etc
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -519,7 +519,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# the default.
 	umoci insert --image "${IMAGE}:${TAG}" "${INSERTDIR}/etc" /etc
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]

--- a/test/raw-add-layer.bats
+++ b/test/raw-add-layer.bats
@@ -56,7 +56,7 @@ function teardown() {
 	# Add layers to the image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}"
+	image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/layer1.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
@@ -100,7 +100,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add layer to the image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}"
+	image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=gzip "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
@@ -130,7 +130,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add layer to the image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}"
+	image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=zstd "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
@@ -160,7 +160,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add layer to the image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}"
+	image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=none "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
@@ -190,7 +190,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add zstd layer to the image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}"
+	image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=zstd "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"

--- a/test/raw-add-layer.bats
+++ b/test/raw-add-layer.bats
@@ -133,7 +133,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	#image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=zstd "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -193,7 +193,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	#image-verify "${IMAGE}"
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=zstd "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -214,7 +214,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add another zstd layer to the image, by making use of the auto selection.
 	umoci raw add-layer --image "${IMAGE}:${TAG}" --compress=auto "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -236,7 +236,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# the default.
 	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/layer.tar"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]

--- a/test/repack.bats
+++ b/test/repack.bats
@@ -928,7 +928,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add layer to the image.
 	umoci repack --image "${IMAGE}:${TAG}" --compress=zstd "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -990,7 +990,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add zstd layer to the image.
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=zstd "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -1013,7 +1013,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# Add another zstd layer to the image, by making use of the auto selection.
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=auto "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -1037,7 +1037,7 @@ OCI_MEDIATYPE_LAYER="application/vnd.oci.image.layer.v1.tar"
 	# the default.
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]

--- a/test/unpack.bats
+++ b/test/unpack.bats
@@ -369,37 +369,37 @@ function teardown() {
 	touch "$ROOTFS/zstd1"
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=zstd "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	# gzip layer
 	touch "$ROOTFS/gzip1"
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=gzip "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	# plain layer
 	touch "$ROOTFS/plain1"
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=none "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	# zstd layer
 	touch "$ROOTFS/zstd2"
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=zstd "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	# plain layer
 	touch "$ROOTFS/plain2"
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle --compress=none "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	# zstd layer (auto)
 	touch "$ROOTFS/zstd3"
 	umoci repack --image "${IMAGE}:${TAG}" --refresh-bundle "$BUNDLE"
 	[ "$status" -eq 0 ]
-	#image-verify "${IMAGE}" # image-tools cannot handle zstd
+	image-verify "${IMAGE}"
 
 	# Re-extract the latest image and make sure all of the files were correctly
 	# extracted.


### PR DESCRIPTION
oci-image-tool broke due to some repo changes in image-spec and so we
can no longer use it as-is. We will move the validation logic to umoci
(as "umoci validate") eventually, but in order to let us merge PRs in
the meantime we need to disable this.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>