### PR TITLE
tests: fix failures on SELinux-enabled systems

### DIFF
--- a/internal/system/xattr_unix_test.go
+++ b/internal/system/xattr_unix_test.go
@@ -28,6 +28,16 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// specialXattrs come from the OCI xattr remapping logic in oci/layer/xattr.go.
+// These are xattrs that will be auto-set by the system and we should ignore
+// their existence when doing xattr-related operations (for our tests, this
+// especially means to take care of them when checking sets of xattrs that
+// exist on the filesystem).
+var specialXattrs = map[string]struct{}{
+	"security.selinux": {},
+	"system.nfs4_acl":  {},
+}
+
 func TestClearxattrFilter(t *testing.T) {
 	dir := t.TempDir()
 
@@ -37,6 +47,12 @@ func TestClearxattrFilter(t *testing.T) {
 
 	path := file.Name()
 	defer os.RemoveAll(path) //nolint:errcheck
+
+	autosetXattrs, err := Llistxattr(path)
+	require.NoErrorf(t, err, "llistxattr %q", path)
+	for _, xattr := range autosetXattrs {
+		require.Contains(t, specialXattrs, xattr, "auto-set xattrs must be part of special list")
+	}
 
 	xattrs := []struct {
 		name, value string
@@ -65,11 +81,16 @@ func TestClearxattrFilter(t *testing.T) {
 		}
 		require.NoErrorf(t, err, "lsetxattr %q=%q on %q", xattr.name, xattr.value, path)
 	}
+	// If we are running on an SELinux-enabled system, all new files get a
+	// security.selinux xattr that gets auto-set and cannot be removed so we
+	// need to include it in the expected set.
+	expectAllXattrNames := append(setXattrNames, autosetXattrs...)
+	expectRemainingXattrNames := append(forbiddenXattrNames, autosetXattrs...)
 
 	// Check they're all present.
 	allXattrList, err := Llistxattr(path)
 	require.NoErrorf(t, err, "llistxattr %q", path)
-	assert.ElementsMatch(t, setXattrNames, allXattrList, "all xattrs should be present after setting")
+	assert.ElementsMatch(t, expectAllXattrNames, allXattrList, "all xattrs should be present after setting")
 
 	// Now clear them.
 	err = Lclearxattrs(path, func(xattrName string) bool {
@@ -79,9 +100,9 @@ func TestClearxattrFilter(t *testing.T) {
 	require.NoErrorf(t, err, "lclearxattrs %q (forbidden=%v)", path, forbiddenXattrs)
 
 	// Check that only the forbidden ones remain.
-	forbiddenXattrList, err := Llistxattr(path)
+	remainingXattrList, err := Llistxattr(path)
 	require.NoErrorf(t, err, "llistxattr %q", path)
-	assert.NotElementsMatch(t, setXattrNames, forbiddenXattrList, "there should be a different set of xattrs after clearing")
-	assert.ElementsMatch(t, forbiddenXattrNames, forbiddenXattrList, "only explicitly forbidden xattrs should be allowed to remain after clearing")
-	assert.NotEmpty(t, forbiddenXattrList, "there should be some remaining xattrs after clearing")
+	assert.NotElementsMatch(t, expectAllXattrNames, remainingXattrList, "there should be a different set of xattrs after clearing")
+	assert.ElementsMatch(t, expectRemainingXattrNames, remainingXattrList, "only explicitly forbidden xattrs should be allowed to remain after clearing")
+	assert.NotEmpty(t, remainingXattrList, "there should be some remaining xattrs after clearing")
 }


### PR DESCRIPTION
Our tests would incorrectly treat security.selinux like a regular xattr,
which lead to failures because it gets auto-set on all new files. The
solution is quite simple -- just include any such xattrs in expected
sets (or filter them out) before doing checks in our tests.

umoci itself still handle security.selinux fine (we emulate it using a
fake user xattr), this is just a bug in our tests' handling of
security.selinux.

Fixes #605
Fixes: 6fd1e0e62645 ("oci: ignore system.nfs4_acl and extend forbidden-xattr handling")
Fixes: 9a1cefaf16bf ("oci: layer: correctly handle trusted.overlay xattr namespace escaping")
Fixes: 54f34c91a8f0 ("oci: layer: refix auto-applied xattr handling")
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>