### PR TITLE
umoci: add raw-mtree-validate helper to replace go-mtree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed ###
 * Some minor aspects of how `umoci stat` would filter special characters in
   history entries have been resolved.
+* `umoci repack` will now truncate the `mtime` of files added to the layer tar
+  archives. Previously, we would defer to the Go stdlib's `archive/tar` which
+  rounds to the nearest second (which is incompatible with `gomtree` and so in
+  theory could lead to inconsistent results).
 
 [source-date-epoch]: https://reproducible-builds.org/docs/source-date-epoch/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   Please let us know if you find any other problematic areas in umoci (we are
   investigating some other possible causes of instability such as Go map
   iteration).
+* In order to avoid the need for a [patched `gomtree` package][obs-gomtree]
+  that supports rootless mode, umoci now has a `umoci raw mtree-validate`
+  subcommand that implements the key `gomtree validate` features we need for
+  our integration tests.
+
+  Note that this subcommand is not intended for wider use outside of our tests
+  (and it is hidden from the help pages for a reason). Most users are probably
+  better off just using `gomtree`.
 
 ### Fixed ###
 * Some minor aspects of how `umoci stat` would filter special characters in
@@ -42,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   theory could lead to inconsistent results).
 
 [source-date-epoch]: https://reproducible-builds.org/docs/source-date-epoch/
+[obs-gomtree]: https://build.opensuse.org/package/show/Virtualization:containers/go-mtree
 
 ## [0.5.1] - 2025-09-05 ##
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@
 FROM golang:1.25 AS go-binaries
 ENV GOPATH=/go PATH=/go/bin:$PATH
 RUN go install github.com/cpuguy83/go-md2man/v2@latest
+RUN go install github.com/vbatts/go-mtree/cmd/gomtree@v0.6.0
 
 ## TOOLS: oci-runtime-tool needs special handling.
 FROM golang:1.25 AS oci-runtime-tool
@@ -51,8 +52,6 @@ RUN skopeo copy docker://$TEST_DOCKER_IMAGE oci:$SOURCE_IMAGE:$SOURCE_TAG
 FROM registry.opensuse.org/opensuse/leap:16.0 AS ci-image
 LABEL org.opencontainers.image.authors="Aleksa Sarai <cyphar@cyphar.com>"
 
-RUN zypper ar -f -p 10 -g 'obs://home:cyphar:containers/$releasever' obs-gomtree && \
-	zypper --gpg-auto-import-keys -n ref
 RUN zypper -n up
 RUN zypper -n in \
 		attr \
@@ -67,7 +66,6 @@ RUN zypper -n in \
 		# Go 1.25's packaging is broken at the moment.
 		# See <https://bugzilla.suse.com/show_bug.cgi?id=1249985>.
 		go1.24 \
-		go-mtree \
 		gzip \
 		jq \
 		libcap-progs \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@
 FROM golang:1.25 AS go-binaries
 ENV GOPATH=/go PATH=/go/bin:$PATH
 RUN go install github.com/cpuguy83/go-md2man/v2@latest
-RUN go install github.com/vbatts/go-mtree/cmd/gomtree@v0.6.0
+# TODO: Get <https://github.com/vbatts/go-mtree/pull/211>,
+#       <https://github.com/vbatts/go-mtree/pull/212>, and
+#       <https://github.com/vbatts/go-mtree/pull/214> merged and switch.
+#RUN go install github.com/vbatts/go-mtree@latest
+RUN git clone -b umoci https://github.com/cyphar/go-mtree.git /tmp/gomtree
+RUN cd /tmp/gomtree && \
+	go install ./cmd/gomtree
 
 ## TOOLS: oci-runtime-tool needs special handling.
 FROM golang:1.25 AS oci-runtime-tool

--- a/cmd/umoci/raw-mtree-validate.go
+++ b/cmd/umoci/raw-mtree-validate.go
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016-2025 SUSE LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/urfave/cli"
+	"github.com/vbatts/go-mtree"
+
+	"github.com/opencontainers/umoci"
+	"github.com/opencontainers/umoci/pkg/fseval"
+)
+
+func parseMtreeKeywordArg(arg string) []mtree.Keyword {
+	names := strings.FieldsFunc(arg, func(ch rune) bool { return ch == ',' || ch == ' ' })
+	keywords := make([]mtree.Keyword, 0, len(names))
+	for _, name := range names {
+		keywords = append(keywords, mtree.KeywordSynonym(name))
+	}
+	return keywords
+}
+
+func cmdParseMtreeKeywords(ctx *cli.Context, name string) {
+	var keywords []mtree.Keyword
+	if arg := ctx.String(name); ctx.IsSet(name) {
+		keywords = parseMtreeKeywordArg(arg)
+	}
+	ctx.App.Metadata["--"+name] = keywords
+}
+
+func uxMtreeKeyword(cmd cli.Command) cli.Command {
+	cmd.Flags = append(cmd.Flags, []cli.Flag{
+		cli.StringFlag{
+			Name:  "add-keywords,K", // for compatibility with gomtree
+			Usage: "add the specified keywords to the set used for validation (delimited by comma or space)",
+		},
+		cli.StringFlag{
+			Name:  "use-keywords,k", // for compatibility with gomtree
+			Usage: "use only the specified keywords for validation (delimited by comma or space)",
+		},
+		cli.BoolFlag{
+			Name:  "umoci-keywords",
+			Usage: "use the default set of keywords used by umoci",
+		},
+	}...)
+
+	oldBefore := cmd.Before
+	cmd.Before = func(ctx *cli.Context) error {
+		cmdParseMtreeKeywords(ctx, "add-keywords")
+		cmdParseMtreeKeywords(ctx, "use-keywords")
+		if oldBefore != nil {
+			return oldBefore(ctx)
+		}
+		return nil
+	}
+
+	return cmd
+}
+
+var rawMtreeValidateCommand = uxMtreeKeyword(uxRootless(cli.Command{
+	Name:  "mtree-validate",
+	Usage: `validate an mtree manifest (akin to "go-mtree validate")`,
+	ArgsUsage: `--manifest <manifest.mtree> --path <directory>
+
+Validate "<directory>" against the mtree(8) manifest in "<manifest.mtree>".
+
+This tool is primarily intended for umoci's integration tests (go-mtree is
+missing rootless support in its CLI), and should not be relied upon by users.`,
+
+	// This is only really used for our tests.
+	Category: "devtools",
+	Hidden:   true,
+
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:     "manifest,f,file", // for compatibility with gomtree
+			Required: true,
+			Usage:    "mtree manifest to validate",
+		},
+		cli.StringFlag{
+			Name:     "path,p", // for compatibility with gomtree
+			Required: true,
+			Usage:    "root path the the mtree manifest is relative to",
+		},
+		// TODO: Do we need --directory-only / -d ?
+	},
+
+	Action: rawMtreeValidate,
+
+	Before: func(ctx *cli.Context) error {
+		if ctx.String("manifest") == "" {
+			return errors.New("--manifest must be a valid path")
+		}
+		if ctx.String("path") == "" {
+			return errors.New("--path must be a valid path")
+		}
+
+		fsEval := fseval.Default
+		if ctx.Bool("rootless") {
+			fsEval = fseval.Rootless
+		}
+		ctx.App.Metadata["fseval"] = fsEval
+
+		return nil
+	},
+}))
+
+func rawMtreeValidate(ctx *cli.Context) (Err error) {
+	manifestPath := ctx.String("manifest")
+	rootPath := ctx.String("path")
+	fsEval := mustFetchMeta[fseval.FsEval](ctx, "fseval")
+
+	addKeywords := mustFetchMeta[[]mtree.Keyword](ctx, "--add-keywords")
+	useKeywords := mustFetchMeta[[]mtree.Keyword](ctx, "--use-keywords")
+
+	log.WithFields(log.Fields{
+		"manifest": manifestPath,
+		"path":     rootPath,
+	}).Debugf("validating directory against mtree manifest")
+
+	log.WithFields(log.Fields{
+		"manifest": manifestPath,
+	}).Info("parsing mtree manifest ...")
+	manifestFile, err := os.Open(manifestPath)
+	if err != nil {
+		return fmt.Errorf("open mtree manifest: %w", err)
+	}
+	defer manifestFile.Close() //nolint:errcheck
+	manifest, err := mtree.ParseSpec(manifestFile)
+	if err != nil {
+		return fmt.Errorf("parse mtree manifest: %w", err)
+	}
+	log.Info("... done")
+
+	// Figure out the set of keywords to use for the comparison.
+	var (
+		compareKeywords  = useKeywords
+		manifestKeywords = manifest.UsedKeywords()
+	)
+	if compareKeywords == nil {
+		if ctx.Bool("umoci-keywords") {
+			compareKeywords = umoci.MtreeKeywords[:]
+		} else {
+			// Just use the manifest keywords if none were specified.
+			compareKeywords = manifestKeywords
+		}
+	}
+	for _, kw := range addKeywords {
+		if !mtree.InKeywordSlice(kw, compareKeywords) {
+			compareKeywords = append(compareKeywords, kw)
+		}
+	}
+	// "type" is necessary for any comparison to make sense.
+	if !mtree.InKeywordSlice("type", compareKeywords) {
+		compareKeywords = append([]mtree.Keyword{"type"}, compareKeywords...)
+	}
+	// NOTE: compareKeywords might contain keywords not in the manifest, but
+	// this is usually okay.
+	log.WithFields(log.Fields{
+		"manifest_keywords": manifestKeywords,
+		"keywords":          compareKeywords,
+	}).Debug("computed set of keywords for mtree comparison")
+
+	log.WithFields(log.Fields{
+		"path": rootPath,
+	}).Info("computing filesystem diff against manifest ...")
+	diff, err := mtree.Check(rootPath, manifest, compareKeywords, fsEval)
+	if err != nil {
+		return fmt.Errorf("check mtree manifest %q against root %q: %w", manifestPath, rootPath, err)
+	}
+	log.Info("... done")
+
+	for _, delta := range diff {
+		fmt.Println(delta)
+	}
+	if n := len(diff); n > 0 {
+		return fmt.Errorf("validation failed: %d differences found", n)
+	}
+	log.Infof("no errors found during mtree validation")
+	return nil
+}

--- a/cmd/umoci/raw.go
+++ b/cmd/umoci/raw.go
@@ -37,5 +37,6 @@ should be sufficient for most use-cases.`,
 		rawAddLayerCommand,
 		rawConfigCommand,
 		rawUnpackCommand,
+		rawMtreeValidateCommand,
 	},
 }

--- a/cmd/umoci/utils_ux.go
+++ b/cmd/umoci/utils_ux.go
@@ -252,6 +252,16 @@ func uxLayout(cmd cli.Command) cli.Command {
 	return cmd
 }
 
+func uxRootless(cmd cli.Command) cli.Command {
+	cmd.Flags = append(cmd.Flags, []cli.Flag{
+		cli.BoolFlag{
+			Name:  "rootless",
+			Usage: "enable rootless command support",
+		},
+	}...)
+	return cmd
+}
+
 func uxRemap(cmd cli.Command) cli.Command {
 	cmd.Flags = append(cmd.Flags, []cli.Flag{
 		cli.StringSliceFlag{
@@ -262,13 +272,8 @@ func uxRemap(cmd cli.Command) cli.Command {
 			Name:  "gid-map",
 			Usage: "specifies a gid mapping to use (container:host:size)",
 		},
-		cli.BoolFlag{
-			Name:  "rootless",
-			Usage: "enable rootless command support",
-		},
 	}...)
-
-	return cmd
+	return uxRootless(cmd)
 }
 
 // fetchMeta returns the requested metadata from the current [cli.Context] as

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/rootless-containers/proto/go-proto v0.0.0-20230421021042-4cd87ebadd67
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli v1.22.12
-	github.com/vbatts/go-mtree v0.6.0
+	github.com/vbatts/go-mtree v0.6.1-0.20250911112631-8307d76bc1b9
 	golang.org/x/sys v0.36.0
 	google.golang.org/protobuf v1.36.9
 )
@@ -57,3 +57,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/vbatts/go-mtree => github.com/cyphar/go-mtree v0.0.0-20250928235313-918fa724e2fe

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.5.0 h1:hIAhkRBMQ8nIeuVwcAoymp7MY4oherZdAxD+m0u9zaw=
 github.com/cyphar/filepath-securejoin v0.5.0/go.mod h1:Sdj7gXlvMcPZsbhwhQ33GguGLDGQL7h7bg04C/+u9jI=
+github.com/cyphar/go-mtree v0.0.0-20250928235313-918fa724e2fe h1:McEMcTs2zpCIZWubd+vGEMpek2rzGl1aPeOcryyD4Tw=
+github.com/cyphar/go-mtree v0.0.0-20250928235313-918fa724e2fe/go.mod h1:M9fxI2xfH2hUj+eQ+ygbyXVFFlGt047SDy9TuF/xteY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -106,8 +108,6 @@ github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPf
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/urfave/cli v1.22.12 h1:igJgVw1JdKH+trcLWLeLwZjU9fEfPesQ+9/e4MQ44S8=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
-github.com/vbatts/go-mtree v0.6.0 h1:n4r+Tweta4oH0+zWfv77VmfvWXrO69smspK37xvzgMI=
-github.com/vbatts/go-mtree v0.6.0/go.mod h1:W7bcG9PCn6lFY+ljGlZxx9DONkxL3v8a7HyN+PrSrjA=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=

--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -155,6 +155,12 @@ func (tg *tarGenerator) AddFile(name, path string) (Err error) {
 	// changes to our output on a compiler bump...
 	hdr.Uname = ""
 	hdr.Gname = ""
+	// archive/tar will round timestamps to their nearest second, while
+	// tar_time (for our mtree validation) will truncate timestamps. For
+	// consistency, explicitly truncate them.
+	hdr.ModTime = hdr.ModTime.Truncate(time.Second)
+	hdr.AccessTime = hdr.AccessTime.Truncate(time.Second)
+	hdr.ChangeTime = hdr.ChangeTime.Truncate(time.Second)
 
 	name, err = normalise(name, fi.IsDir())
 	if err != nil {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -203,7 +203,7 @@ function mtree-validate() {
 		# In the non-rootless case, we should cross-check that umoci's mtree is
 		# not accidentally ignoring mtree errors. Upstream gomtree doesn't
 		# support rootless mode.
-		sane_run gomtree validate -K sha256digest "$@"
+		sane_run gomtree validate --strict -K sha256digest "$@"
 
 		[[ "$status" == "$umoci_status" ]] || fail "umoci raw mtree-validate and gomtree have different results"
 	fi

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -186,7 +186,7 @@ function umoci() {
 	args+=("$1")
 
 	# Set --rootless for commands that require it when we're rootless.
-	if [[ "$IS_ROOTLESS" != 0 && "$1" =~ unpack|insert ]]; then
+	if [[ "$IS_ROOTLESS" != 0 && "$1" =~ unpack|insert|mtree-validate ]]; then
 		args+=("--rootless")
 	fi
 

--- a/test/raw-mtree-validate.bats
+++ b/test/raw-mtree-validate.bats
@@ -1,0 +1,260 @@
+#!/usr/bin/env bats -t
+# SPDX-License-Identifier: Apache-2.0
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2016-2025 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+function setup() {
+	setup_tmpdirs
+	setup_image
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+}
+
+@test "umoci raw mtree-validate [unpacked rootfs]" {
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	# mtree-validate should pass for a rootfs we just extracted.
+	umoci raw mtree-validate -K sha256digest -f "$BUNDLE"/sha256_*.mtree -p "$ROOTFS"
+	[ "$status" -eq 0 ]
+	# Make sure that regular gomtree succeeds (for rootful runs).
+	if [[ "$IS_ROOTLESS" == 0 ]]; then
+		sane_run gomtree validate --strict -K sha256digest -f "$BUNDLE"/sha256_*.mtree -p "$ROOTFS"
+		[ "$status" -eq 0 ]
+	fi
+	# Use mtree-validate wrapper.
+	mtree-validate -f "$BUNDLE"/sha256_*.mtree -p "$ROOTFS"
+	[ "$status" -eq 0 ]
+
+	# Modify the rootfs.
+	touch -d "1997-03-25T13:40:00.12345" "$ROOTFS/etc/passwd"
+
+	# mtree-validate should fail for a rootfs we modified.
+	umoci raw mtree-validate -K sha256digest -f "$BUNDLE"/sha256_*.mtree -p "$ROOTFS"
+	[ "$status" -ne 0 ]
+	# Make sure that regular gomtree fails (for rootful runs).
+	if [[ "$IS_ROOTLESS" == 0 ]]; then
+		sane_run gomtree validate --strict -K sha256digest -f "$BUNDLE"/sha256_*.mtree -p "$ROOTFS"
+		[ "$status" -ne 0 ]
+	fi
+	# Use mtree-validate wrapper.
+	mtree-validate -f "$BUNDLE"/sha256_*.mtree -p "$ROOTFS"
+	[ "$status" -ne 0 ]
+}
+
+@test "umoci raw mtree-validate [basic manifest]" {
+	tmpdir="$(setup_tmpdir)"
+	rootfs="$tmpdir/rootfs"
+	manifest="$tmpdir/rootfs.mtree"
+
+	# Create some dummy files.
+	mkdir -p "$rootfs/foo/bar/baz"
+	echo "foobar" >"$rootfs/foobar"
+	echo "test" > "$rootfs/foo/bar/baz/boop"
+	touch -d "1997-03-25T13:40:12" "$rootfs/aki"
+	touch -d "2025-09-05T13:05:34" "$rootfs/yuki"
+
+	# Construct a manifest.
+	sane_run gomtree -c -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+	[ -f "$manifest" ]
+
+	umoci raw mtree-validate -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+	sane_run gomtree validate --strict -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+
+	touch "$rootfs/aki"
+
+	umoci raw mtree-validate -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+	sane_run gomtree validate --strict -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+}
+
+@test "umoci raw mtree-validate -k" {
+	tmpdir="$(setup_tmpdir)"
+	rootfs="$tmpdir/rootfs"
+	manifest="$tmpdir/rootfs.mtree"
+
+	# Create some dummy files.
+	mkdir -p "$rootfs/foo/bar/baz"
+	echo "foobar" >"$rootfs/foobar"
+	echo "test" > "$rootfs/foo/bar/baz/boop"
+	touch -d "1997-03-25T13:40:22" "$rootfs/aki"
+	touch -d "2025-09-05T13:05:33" "$rootfs/yuki"
+
+	# Construct a manifest.
+	sane_run gomtree -c -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+	[ -f "$manifest" ]
+
+	touch "$rootfs/aki"
+	touch "$rootfs/yuki"
+
+	umoci raw mtree-validate -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+	sane_run gomtree validate --strict -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+
+	# -k without time should result in no deltas.
+	umoci raw mtree-validate -k sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+	sane_run gomtree validate --strict -k sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+
+	# -k with key not in manifest should error out.
+	umoci raw mtree-validate -k sha1digest -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *'keyword "sha1digest"'* ]]
+}
+
+@test "umoci raw mtree-validate -K" {
+	tmpdir="$(setup_tmpdir)"
+	rootfs="$tmpdir/rootfs"
+	manifest="$tmpdir/rootfs.mtree"
+
+	# Create some dummy files.
+	mkdir -p "$rootfs/foo/bar/baz"
+	echo "foobar" >"$rootfs/foobar"
+	echo "test" > "$rootfs/foo/bar/baz/boop"
+	touch -d "1997-03-25T13:40:44" "$rootfs/aki"
+	touch -d "2025-09-05T13:05:55" "$rootfs/yuki"
+
+	# Construct a manifest.
+	sane_run gomtree -c -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+	[ -f "$manifest" ]
+
+	# -K with already set keywords should just work.
+	umoci raw mtree-validate -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+	sane_run gomtree validate --strict -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -eq 0 ]
+
+	# -K with key not in manifest should error out.
+	umoci raw mtree-validate -K sha1digest -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *'keyword "sha1digest"'* ]]
+
+	touch "$rootfs/aki"
+	touch "$rootfs/yuki"
+
+	umoci raw mtree-validate -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+	sane_run gomtree validate --strict -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+
+	# -K doesn't clear the set of   without time should result in no deltas.
+	umoci raw mtree-validate -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+	sane_run gomtree validate --strict -K sha256digest -p "$rootfs" -f "$manifest"
+	[ "$status" -ne 0 ]
+}
+
+# See the 0012trunc.sh test in <https://github.com/vbatts/go-mtree/pull/209>.
+@test "umoci raw mtree-validate [tar_time]" {
+	tmpdir="$(setup_tmpdir)"
+	rootfs="$tmpdir/rootfs"
+	time_manifest="$tmpdir/rootfs.mtree"
+	tartime_manifest="$tmpdir/rootfs-tartime.mtree"
+
+	# Create some dummy files.
+	mkdir -p "$rootfs"
+	date="2025-09-05T13:05:10"
+	touch -d "$date.1000" "$rootfs/lowerhalf"
+	touch -d "$date.8000" "$rootfs/upperhalf"
+	touch -d "$date.0000" "$rootfs/tartime"
+
+	keywords=type,uid,gid,nlink,link,mode,flags,xattr,size,sha256digest
+	sane_run gomtree -c -k "$keywords,time" -p "$rootfs" -f "$time_manifest"
+	[ "$status" -eq 0 ]
+	[ -f "$time_manifest" ]
+	sane_run gomtree -c -k "$keywords,tar_time" -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -eq 0 ]
+	[ -f "$tartime_manifest" ]
+
+	# Make sure tar_time truncated the value.
+	unix="$(date -d "$date" +%s)"
+	grep -Eq "lowerhalf.*\<tar_time=$unix\.0{9}\>" "$tartime_manifest"
+	grep -Eq "upperhalf.*\<tar_time=$unix\.0{9}\>" "$tartime_manifest"
+	grep -Eq "tartime.*\<tar_time=$unix\.0{9}\>" "$tartime_manifest"
+
+	# Validation should work.
+	umoci raw mtree-validate -p "$rootfs" -f "$time_manifest"
+	[ "$status" -eq 0 ]
+	umoci raw mtree-validate -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -eq 0 ]
+	# Even if we force the usage of the opposite time type.
+	umoci raw mtree-validate -k "$keywords,tar_time" -p "$rootfs" -f "$time_manifest"
+	[ "$status" -eq 0 ]
+	umoci raw mtree-validate -k "$keywords,time" -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -eq 0 ]
+
+	# Manually truncate the mtime.
+	touch -d "$date.0000" "$rootfs/lowerhalf"
+	touch -d "$date.0000" "$rootfs/upperhalf"
+	touch -d "$date.0000" "$rootfs/tartime"
+
+	# Now only tar_time validation should work.
+	umoci raw mtree-validate -p "$rootfs" -f "$time_manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lowerhalf"* ]]
+	[[ "$output" == *"upperhalf"* ]]
+	[[ "$output" != *"tartime"* ]] # no difference after truncation
+	umoci raw mtree-validate -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -eq 0 ]
+	# If we force the usage of the opposite time type, as long as one time type
+	# is tar_time then validation should still work.
+	umoci raw mtree-validate -k "$keywords,tar_time" -p "$rootfs" -f "$time_manifest"
+	[ "$status" -eq 0 ]
+	umoci raw mtree-validate -k "$keywords,time" -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -eq 0 ]
+
+	# Modify the mtime completely.
+	touch -d "1997-03-25T13:40:00.0000" "$rootfs/lowerhalf"
+	touch -d "1997-03-25T13:40:00.0000" "$rootfs/upperhalf"
+	touch -d "1997-03-25T13:40:00.0000" "$rootfs/tartime"
+
+	# All validations should now fail.
+	umoci raw mtree-validate -p "$rootfs" -f "$time_manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lowerhalf"* ]]
+	[[ "$output" == *"upperhalf"* ]]
+	[[ "$output" == *"tartime"* ]]
+	umoci raw mtree-validate -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lowerhalf"* ]]
+	[[ "$output" == *"upperhalf"* ]]
+	[[ "$output" == *"tartime"* ]]
+	# Even if we force the usage of the opposite time type.
+	umoci raw mtree-validate -p "$rootfs" -f "$time_manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lowerhalf"* ]]
+	[[ "$output" == *"upperhalf"* ]]
+	[[ "$output" == *"tartime"* ]]
+	umoci raw mtree-validate -p "$rootfs" -f "$tartime_manifest"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"lowerhalf"* ]]
+	[[ "$output" == *"upperhalf"* ]]
+	[[ "$output" == *"tartime"* ]]
+}

--- a/test/raw-unpack.bats
+++ b/test/raw-unpack.bats
@@ -119,8 +119,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
-	# Ensure that gomtree succeeds on the new unpacked rootfs.
-	gomtree -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
+	# Ensure that mtree validation succeeds on the new unpacked rootfs.
+	mtree-validate -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 

--- a/test/repack.bats
+++ b/test/repack.bats
@@ -57,9 +57,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
-	# Ensure that gomtree succeeds on the old bundle, which is what this was
-	# generated from.
-	gomtree -p "$ROOTFS" -f "$BUNDLE"/sha256_*.mtree
+	# Ensure that mtree validation succeeds on the old bundle, which is what
+	# this was generated from.
+	mtree-validate -p "$ROOTFS" -f "$BUNDLE"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 
@@ -209,9 +209,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
-	# Ensure that gomtree succeeds on the old bundle, which is what this was
-	# generated from.
-	gomtree -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
+	# Ensure that mtree validation succeeds on the old bundle, which is what
+	# this was generated from.
+	mtree-validate -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 
@@ -273,9 +273,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
-	# Ensure that gomtree succeeds on the old bundle, which is what this was
-	# generated from.
-	gomtree -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
+	# Ensure that mtree validation succeeds on the old bundle, which is what
+	# this was generated from.
+	mtree-validate -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 
@@ -795,8 +795,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
-	# Ensure the gomtree has been refreshed in the bundle
-	gomtree -p "$ROOTFS" -f "$BUNDLE"/sha256_*.mtree
+	# Ensure the mtree manifest has been refreshed in the bundle
+	mtree-validate -p "$ROOTFS" -f "$BUNDLE"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 
@@ -806,12 +806,12 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
-	# Ensure that gomtree succeeds across bundles - they should be the same rootfs
-	# and have the same mtree manifest
-	gomtree -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
+	# Ensure that mtree validation succeeds across bundles - they should be the
+	# same rootfs and have the same mtree manifest
+	mtree-validate -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
-	gomtree -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
+	mtree-validate -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 
@@ -830,10 +830,10 @@ function teardown() {
 	bundle-verify "$BUNDLE"
 
 	# Ensure all changes are reflected
-	gomtree -p "$ROOTFS_A" -f "$BUNDLE_C"/sha256_*.mtree
+	mtree-validate -p "$ROOTFS_A" -f "$BUNDLE_C"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
-	gomtree -p "$ROOTFS_C" -f "$BUNDLE_C"/sha256_*.mtree
+	mtree-validate -p "$ROOTFS_C" -f "$BUNDLE_C"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 

--- a/test/unpack.bats
+++ b/test/unpack.bats
@@ -45,8 +45,8 @@ function teardown() {
 	[ -e "$ROOTFS/etc/passwd" ]
 	[ -e "$ROOTFS/etc/group" ]
 
-	# Ensure that gomtree succeeds on the unpacked bundle.
-	gomtree -p "$ROOTFS" -f "$BUNDLE"/sha256_*.mtree
+	# Ensure that mtree validation succeeds on the unpacked bundle.
+	mtree-validate -p "$ROOTFS" -f "$BUNDLE"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 
@@ -144,11 +144,11 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
-	# Ensure that gomtree cross-succeeds.
-	gomtree -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
+	# Ensure that mtree validation cross-succeeds.
+	mtree-validate -p "$ROOTFS_A" -f "$BUNDLE_B"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
-	gomtree -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
+	mtree-validate -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 

--- a/vendor/github.com/vbatts/go-mtree/entry.go
+++ b/vendor/github.com/vbatts/go-mtree/entry.go
@@ -147,6 +147,15 @@ func (e Entry) AllKeys() []KeyVal {
 	return e.Keywords
 }
 
+func (e Entry) allKeysMap() map[Keyword]KeyVal {
+	all := e.AllKeys()
+	keyMap := make(map[Keyword]KeyVal, len(all))
+	for _, kv := range all {
+		keyMap[kv.Keyword()] = kv
+	}
+	return keyMap
+}
+
 // IsDir checks the type= value for this entry on whether it is a directory
 func (e Entry) IsDir() bool {
 	for _, kv := range e.AllKeys() {

--- a/vendor/github.com/vbatts/go-mtree/pkg/govis/README.md
+++ b/vendor/github.com/vbatts/go-mtree/pkg/govis/README.md
@@ -11,7 +11,7 @@ Because 80s BSD code is not very nice to read.
 
 ```
 govis: unicode aware vis(3) encoding implementation
-Copyright (C) 2017 SUSE LLC.
+Copyright (C) 2017-2025 SUSE LLC.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/github.com/vbatts/go-mtree/pkg/govis/govis.go
+++ b/vendor/github.com/vbatts/go-mtree/pkg/govis/govis.go
@@ -1,6 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
  * govis: unicode aware vis(3) encoding implementation
- * Copyright (C) 2017 SUSE LLC.
+ * Copyright (C) 2017-2025 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,13 @@
 
 package govis
 
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // VisFlag manipulates how the characters are encoded/decoded
 type VisFlag uint
 
@@ -24,16 +32,73 @@ type VisFlag uint
 // mtree only uses one set of flags, implementing them all is necessary in
 // order to have compatibility with BSD's vis() and unvis() commands.
 const (
-	VisOctal     VisFlag = (1 << iota)     // VIS_OCTAL: Use octal \ddd format.
-	VisCStyle                              // VIS_CSTYLE: Use \[nrft0..] where appropriate.
-	VisSpace                               // VIS_SP: Also encode space.
-	VisTab                                 // VIS_TAB: Also encode tab.
-	VisNewline                             // VIS_NL: Also encode newline.
-	VisSafe                                // VIS_SAFE: Encode unsafe characters.
-	VisNoSlash                             // VIS_NOSLASH: Inhibit printing '\'.
-	VisHTTPStyle                           // VIS_HTTPSTYLE: HTTP-style escape %xx.
-	VisGlob                                // VIS_GLOB: Encode glob(3) magics.
-	visMask      VisFlag = (1 << iota) - 1 // Mask of all flags.
+	VisOctal       VisFlag = (1 << iota)     // VIS_OCTAL: Use octal \ddd format.
+	VisCStyle                                // VIS_CSTYLE: Use \[nrft0..] where appropriate.
+	VisSpace                                 // VIS_SP: Also encode space.
+	VisTab                                   // VIS_TAB: Also encode tab.
+	VisNewline                               // VIS_NL: Also encode newline.
+	VisSafe                                  // VIS_SAFE: Encode unsafe characters.
+	VisNoSlash                               // VIS_NOSLASH: Inhibit printing '\'.
+	VisHTTPStyle                             // VIS_HTTPSTYLE: HTTP-style escape %xx.
+	VisGlob                                  // VIS_GLOB: Encode glob(3) magics.
+	VisDoubleQuote                           // VIS_DQ: Encode double-quotes (").
+	visMask        VisFlag = (1 << iota) - 1 // Mask of all flags.
 
 	VisWhite VisFlag = (VisSpace | VisTab | VisNewline)
 )
+
+// errUnknownVisFlagsError is a special value that lets you use [errors.Is]
+// with [unknownVisFlagsError]. Don't actually return this value, use
+// [unknownVisFlagsError] instead!
+var errUnknownVisFlagsError = errors.New("unknown or unsupported vis flags")
+
+// unknownVisFlagsError represents an error caused by unknown [VisFlag]s being
+// passed to [Vis] or [Unvis].
+type unknownVisFlagsError struct {
+	flags VisFlag
+}
+
+func (err unknownVisFlagsError) Is(target error) bool {
+	return target == errUnknownVisFlagsError
+}
+
+func (err unknownVisFlagsError) Error() string {
+	return fmt.Sprintf("%s contains unknown or unsupported flags %s", err.flags, err.flags&^visMask)
+}
+
+// String pretty-prints VisFlag.
+func (vflags VisFlag) String() string {
+	flagNames := []struct {
+		name string
+		bits VisFlag
+	}{
+		{"VisOctal", VisOctal},
+		{"VisCStyle", VisCStyle},
+		{"VisSpace", VisSpace},
+		{"VisTab", VisTab},
+		{"VisNewline", VisNewline},
+		{"VisSafe", VisSafe},
+		{"VisNoSlash", VisNoSlash},
+		{"VisHTTPStyle", VisHTTPStyle},
+		{"VisGlob", VisGlob},
+	}
+	var (
+		flagSet  = make([]string, 0, len(flagNames))
+		seenBits VisFlag
+	)
+	for _, flag := range flagNames {
+		if vflags&flag.bits == flag.bits {
+			seenBits |= flag.bits
+			flagSet = append(flagSet, flag.name)
+		}
+	}
+	// If there were any remaining flags specified we don't know the name of,
+	// just add them in an 0x... format.
+	if remaining := vflags &^ seenBits; remaining != 0 {
+		flagSet = append(flagSet, "0x"+strconv.FormatUint(uint64(remaining), 16))
+	}
+	if len(flagSet) == 0 {
+		return "0"
+	}
+	return strings.Join(flagSet, "|")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -96,7 +96,7 @@ github.com/stretchr/testify/require
 # github.com/urfave/cli v1.22.12
 ## explicit; go 1.11
 github.com/urfave/cli
-# github.com/vbatts/go-mtree v0.6.0
+# github.com/vbatts/go-mtree v0.6.1-0.20250911112631-8307d76bc1b9 => github.com/cyphar/go-mtree v0.0.0-20250928235313-918fa724e2fe
 ## explicit; go 1.24.0
 github.com/vbatts/go-mtree
 github.com/vbatts/go-mtree/pkg/govis
@@ -142,3 +142,4 @@ google.golang.org/protobuf/runtime/protoimpl
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/vbatts/go-mtree => github.com/cyphar/go-mtree v0.0.0-20250928235313-918fa724e2fe


### PR DESCRIPTION
The go-mtree CLI does not support rootless operations, which requires us
to use a patched version maintained in my OBS home project. This is a
little silly, and really we should just have a helper that calls
mtree.Check() with fseval.Rootless when in rootless mode.

At the moment, we only support the minimal set of flags needed for our
tests and the command is hidden from our help pages.

Closes #621
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>