### PR TITLE
gha: run rootless and rootful integration in parallel

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -49,7 +49,7 @@ jobs:
       uses: google/clusterfuzzlite/actions/run_fuzzers@v1
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        fuzz-seconds: 600
+        fuzz-seconds: 300
         mode: 'code-change'
         sanitizer: ${{ matrix.sanitizer }}
         output-sarif: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,3 +202,15 @@ jobs:
         with:
           name: coverage
           path: ${{ env.GOCOVERDIR }}
+
+  complete:
+    runs-on: ubuntu-latest
+    needs:
+      - release
+      - validate
+      - macos
+      - unit
+      - integration
+      - coverage
+    steps:
+      - run: echo "all done"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,9 @@ jobs:
           - debian:latest
           - ubuntu:latest
           - fedora:latest
+        test:
+          - root
+          - rootless
     env:
       TEST_DOCKER_IMAGE: ${{ matrix.image }}
       COVERAGE: umoci.coverage
@@ -165,7 +168,7 @@ jobs:
             ${{ github.workflow }}-image-
       - name: load ci image
         run: make ci-cache
-      - run: make TEST_DOCKER_IMAGE=$TEST_DOCKER_IMAGE test-integration
+      - run: make TEST_DOCKER_IMAGE=$TEST_DOCKER_IMAGE test-${{ matrix.test }}-integration
       - run: go tool covdata textfmt -i "$GOCOVERDIR" -o "$COVERAGE"
       - name: codecov
         uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ CI_CACHE_PATH ?=.ci-cache
 .PHONY: ci-cache
 ci-cache: BUILDX_CACHE := \
 	--cache-from=type=local,src=$(CI_CACHE_PATH) \
-	--cache-to=type=local,mode=max,dest=$(CI_CACHE_PATH)
+	--cache-to=type=local,dest=$(CI_CACHE_PATH)
 ci-cache: ci-image
 
 .PHONY: ci-image

--- a/Makefile
+++ b/Makefile
@@ -187,9 +187,16 @@ local-test-unit:
 TESTS ?=
 
 .PHONY: test-integration
-test-integration: ci-image
+test-integration: test-root-integration test-rootless-integration
+
+.PHONY: test-root-integration
+test-root-integration: ci-image umoci.cover
 	mkdir -p $(GOCOVERDIR) && chmod a+rwx $(GOCOVERDIR)
 	$(DOCKER_ROOTPRIV_RUN) -e GOCOVERDIR -e TESTS $(UMOCI_IMAGE) make local-test-integration
+
+.PHONY: test-rootless-integration
+test-rootless-integration: ci-image umoci.cover
+	mkdir -p $(GOCOVERDIR) && chmod a+rwx $(GOCOVERDIR)
 	$(DOCKER_ROOTLESS_RUN) -e GOCOVERDIR -e TESTS $(UMOCI_IMAGE) make local-test-integration
 
 .PHONY: local-test-integration


### PR DESCRIPTION
This lets us easily halve the execution time of CI runs and provides
more feedback about bugs that only affect rootful or rootless runs.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>