### PR TITLE
Do not assume Linux OCI images (can be useful for FreeBSD, etc.)

### DIFF
--- a/oci/config/convert/runtime.go
+++ b/oci/config/convert/runtime.go
@@ -117,10 +117,6 @@ func MutateRuntimeSpec(spec *rspec.Spec, rootfs string, image ispec.Image) error
 		return fmt.Errorf("creating image generator: %w", err)
 	}
 
-	if ig.PlatformOS() != "linux" {
-		return fmt.Errorf("unsupported OS: %s", image.OS)
-	}
-
 	allocateNilStruct(spec)
 
 	// Default config to our rspec version if none was specified.


### PR DESCRIPTION
I wanted to unpack a FreeBSD OCI image and had to remove the `PlatformOS` check first. Would it be OK to drop it altogether?