### PR TITLE
oci: convert: do not overwrite explicitly configured HOME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] ##
 
+### Fixed ###
+* Previously umoci would always overwrite the `HOME` environment variable with
+  the home directory configured in the container image's `/etc/passwd` (if the
+  the configured user existed). This was different to other OCI runtimes and
+  was a violation of the policy that user-configured data should always take
+  priority. Umoci will now only add the auto-generated `HOME` environment
+  variable if no such variable was configured in `Config.Env`. (#652)
+
 ## [0.6.0] - 2025-10-15 ##
 
 > Please mind the gap between the train and the platform.

--- a/oci/config/convert/runtime.go
+++ b/oci/config/convert/runtime.go
@@ -76,11 +76,13 @@ func parseEnv(env string) (string, string, error) {
 
 // appendEnv takes a (name, value) pair and inserts it into the given
 // environment list (overwriting an existing environment if already set).
-func appendEnv(env *[]string, name, value string) {
+func appendEnv(env *[]string, name, value string, clobber bool) {
 	val := name + "=" + value
 	for idx, oldVal := range *env {
 		if strings.HasPrefix(oldVal, name+"=") {
-			(*env)[idx] = val
+			if clobber {
+				(*env)[idx] = val
+			}
 			return
 		}
 	}
@@ -157,7 +159,7 @@ func MutateRuntimeSpec(spec *rspec.Spec, rootfs string, image ispec.Image) error
 		if err != nil {
 			return fmt.Errorf("parsing image.Config.Env: %w", err)
 		}
-		appendEnv(&spec.Process.Env, name, value)
+		appendEnv(&spec.Process.Env, name, value, true)
 	}
 
 	args := []string{}
@@ -214,7 +216,7 @@ func MutateRuntimeSpec(spec *rspec.Spec, rootfs string, image ispec.Image) error
 	}
 
 	if execUser.Home != "" {
-		appendEnv(&spec.Process.Env, "HOME", execUser.Home)
+		appendEnv(&spec.Process.Env, "HOME", execUser.Home, false)
 	}
 
 	for _, vol := range ig.ConfigVolumes() {


### PR DESCRIPTION
User data should always take precedence, but we would forcefully
overwrite HOME with the value in /etc/passwd (if we found it). We should
only set HOME if it is not already set.

Fixes #652
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>