### PR TITLE
feat(raw-unpack): Add --start-from-digest flag

### DIFF
--- a/cmd/umoci/raw-unpack.go
+++ b/cmd/umoci/raw-unpack.go
@@ -52,6 +52,11 @@ is the destination to unpack the image to.`,
 			Name:  "keep-dirlinks",
 			Usage: "don't clobber underlying symlinks to directories",
 		},
+		cli.StringFlag{
+			Name:  "start-from-digest",
+			Usage: "start unpacking from the given layer digest",
+			Value: "",
+		},
 	},
 
 	Action: rawUnpack,
@@ -132,6 +137,19 @@ func rawUnpack(ctx *cli.Context) (Err error) {
 	if !ok {
 		// Should _never_ be reached.
 		return fmt.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.Descriptor.MediaType)
+	}
+
+	startFromDigest := ctx.String("start-from-digest")
+	if startFromDigest != "" {
+		for _, layer := range manifest.Layers {
+			if layer.Digest.String() == startFromDigest {
+				unpackOptions.StartFrom = layer
+				break
+			}
+		}
+		if unpackOptions.StartFrom.MediaType == "" {
+			return fmt.Errorf("start-from-digest: %s not found in manifest", startFromDigest)
+		}
 	}
 
 	log.Warnf("unpacking rootfs ...")


### PR DESCRIPTION
# Context

Add a small flag to `raw unpack` command to support unpacking from a specific layer.

Let me know if we want users to provide just the digest without `sha256:` prefix instead

# Demo

<img width="1063" height="118" alt="image" src="https://github.com/user-attachments/assets/7d7f2dee-6347-4b18-ac4b-53e3f15dfd5f" />
