### PR TITLE
oci/layer: error instead of panic when diff_ids and layer counts differ

### DIFF
--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -249,6 +249,13 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 		return fmt.Errorf("unpack rootfs: config: unsupported rootfs.type: %s", config.RootFS.Type)
 	}
 
+	// Both of these slices come from the untrusted image, so we cannot assume
+	// they line up. Bail out with a clear error rather than letting the loop
+	// below index config.RootFS.DiffIDs out of range and panic.
+	if len(manifest.Layers) != len(config.RootFS.DiffIDs) {
+		return fmt.Errorf("unpack rootfs: config: number of diff_ids (%d) does not match number of manifest layers (%d)", len(config.RootFS.DiffIDs), len(manifest.Layers))
+	}
+
 	// Layer extraction.
 	found := false
 	for idx, layerDescriptor := range manifest.Layers {

--- a/oci/layer/unpack_test.go
+++ b/oci/layer/unpack_test.go
@@ -205,6 +205,53 @@ func TestUnpackStartFromDescriptor(t *testing.T) {
 	assert.ErrorIs(t, err, os.ErrNotExist, "test file should not be present")
 }
 
+// A crafted image whose manifest lists more layers than the config has
+// diff_ids (both come from the untrusted image) used to walk off the end of
+// config.RootFS.DiffIDs and panic. Make sure we return an error instead.
+func TestUnpackManifestLayerDiffIDMismatch(t *testing.T) {
+	_, manifest, engineExt := makeImage(t)
+	require.Greater(t, len(manifest.Layers), 1, "test image needs at least two layers")
+
+	// Grab the original config so we can build a corrupted variant with fewer
+	// diff_ids than the manifest has layers.
+	configBlob, err := engineExt.FromDescriptor(t.Context(), manifest.Config)
+	require.NoError(t, err)
+	defer configBlob.Close() //nolint:errcheck // read-only blob
+	config, ok := configBlob.Data.(ispec.Image)
+	require.True(t, ok, "config blob should decode to an image")
+
+	// Drop the last diff_id so the counts no longer line up.
+	config.RootFS.DiffIDs = config.RootFS.DiffIDs[:len(config.RootFS.DiffIDs)-1]
+
+	configDigest, configSize, err := engineExt.PutBlobJSON(t.Context(), config)
+	require.NoError(t, err)
+	manifest.Config = ispec.Descriptor{
+		MediaType: ispec.MediaTypeImageConfig,
+		Digest:    configDigest,
+		Size:      configSize,
+	}
+
+	unpackOptions := &UnpackOptions{
+		OnDiskFormat: DirRootfs{
+			MapOptions: MapOptions{
+				UIDMappings: []rspec.LinuxIDMapping{
+					{HostID: uint32(os.Geteuid()), ContainerID: 0, Size: 1},
+					{HostID: uint32(os.Geteuid()), ContainerID: 1000, Size: 1},
+				},
+				GIDMappings: []rspec.LinuxIDMapping{
+					{HostID: uint32(os.Getegid()), ContainerID: 0, Size: 1},
+					{HostID: uint32(os.Getegid()), ContainerID: 100, Size: 1},
+				},
+				Rootless: os.Geteuid() != 0,
+			},
+		},
+	}
+	bundle := t.TempDir()
+	err = UnpackManifest(t.Context(), engineExt, bundle, manifest, unpackOptions)
+	require.Error(t, err, "UnpackManifest with mismatched diff_ids should fail cleanly")
+	assert.Contains(t, err.Error(), "does not match number of manifest layers")
+}
+
 // TODO: Temporary until <https://github.com/opencontainers/umoci/issues/574>
 // is resolved.
 func TestUnpackUnimplementedOverlayfs(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -696,8 +696,13 @@ func Stat(ctx context.Context, engine casext.Engine, manifestDescriptor ispec.De
 				Layer:   nil,
 			}
 			// Only fill the other information and increment layerIdx if it's a
-			// non-empty layer.
+			// non-empty layer. Both slices come from the untrusted image, so a
+			// mismatch between the history and the diff_ids/layers must not be
+			// allowed to index out of range and panic.
 			if !histEntry.EmptyLayer {
+				if layerIdx >= len(config.RootFS.DiffIDs) || layerIdx >= len(manifest.Layers) {
+					return stat, fmt.Errorf("stat: config: number of non-empty history entries exceeds number of diff_ids (%d) or manifest layers (%d)", len(config.RootFS.DiffIDs), len(manifest.Layers))
+				}
 				info.DiffID = config.RootFS.DiffIDs[layerIdx]
 				info.Layer = &manifest.Layers[layerIdx]
 				layerIdx++


### PR DESCRIPTION
I've been looking at umoci's unpack path from a supply-chain angle, specifically what happens when the image metadata is hostile rather than well-formed.

A manifest's `layers` list and the config's `rootfs.diff_ids` are both taken straight from the (untrusted) image, but nothing checks that the two line up. If a crafted image lists more layers than there are diff_ids, `UnpackRootfs` panics:

- `oci/layer/unpack.go`: the extraction loop does `layerDiffID := config.RootFS.DiffIDs[idx]` where `idx` ranges over `manifest.Layers`, so a shorter `DiffIDs` runs off the end with an index-out-of-range.
- `utils.go` (`Stat`): the history walk indexes `config.RootFS.DiffIDs[layerIdx]` and `manifest.Layers[layerIdx]` by a counter that increments per non-empty history entry, again with no bounds check.

This turns a malformed image into a panic instead of a clean error, which isn't great for anything that unpacks or inspects untrusted images.

The change adds a length guard before the unpack loop and a bounds check before the stat indexing, so umoci now returns an error that names the mismatched counts. I added a regression test that builds an image whose config drops one diff_id and asserts `UnpackManifest` returns an error rather than panicking.

Worth noting the existing fuzzer (`layer_fuzzer.go`) constructs the config's diff_ids to be exactly as long as the layer list, so it never exercises this mismatch, which is probably why it went unnoticed.

`go test ./oci/layer/...` for the affected tests passes, and `gofmt`/`go vet` are clean. (`TestGenerate` fails on my macOS box independently of this change, since it exercises Linux-only lstat behaviour.)